### PR TITLE
Improve mock data and reader defaults

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- improve mock data generation, update H5Reader defaults [#10](https://github.com/umami-hep/atlas-ftag-tools/pull/10)
 - add git hash to files written with H5Writer [#9](https://github.com/umami-hep/atlas-ftag-tools/pull/9)
 
 ### [v0.0.4]

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- add git hash to files written with H5Writer [#9](https://github.com/umami-hep/atlas-ftag-tools/pull/9)
 
 ### [v0.0.4]
 - set uniform python version in docker and actions [#7](https://github.com/umami-hep/atlas-ftag-tools/pull/7)

--- a/ftag/__init__.py
+++ b/ftag/__init__.py
@@ -10,6 +10,7 @@ import yaml
 import ftag.hdf5 as hdf5
 from ftag.cuts import Cuts
 from ftag.flavour import Flavour, FlavourContainer
+from ftag.mock import get_mock_file
 from ftag.sample import Sample
 
 # load flavours
@@ -19,4 +20,4 @@ flavours_dict = {f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for
 assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
 Flavours = FlavourContainer(flavours_dict)
 
-__all__ = ["Cuts", "Flavours", "Sample", "hdf5", "__version__"]
+__all__ = ["Cuts", "Flavours", "Sample", "hdf5", "get_mock_file", "__version__"]

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -1,6 +1,16 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -26,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -147,7 +157,7 @@
        "Flavour(name='bjets', label='$b$-jets', cuts=['HadronConeExclTruthLabelID == 5'], colour='tab:blue', category='single-btag')"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -168,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -177,7 +187,7 @@
        "Flavour(name='qcd', label='QCD', cuts=['R10TruthLabel_R22v1 == 10'], colour='#38761D', category='xbb')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -197,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -223,7 +233,7 @@
        "['single-btag', 'single-btag-extended', 'xbb', 'partonic', 'lepton-decay']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,7 +244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -243,7 +253,7 @@
        "FlavourContainer(hbb, hcc, top, qcd)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -262,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -271,7 +281,7 @@
        "['pb', 'pc', 'pu', 'ptau']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -291,13 +301,14 @@
     "\n",
     "- Variables are specified as `dict[str, list[str]]`.\n",
     "- By default the reader will randomly access chunks in the file, giving you a weakly shuffled set of jets.\n",
+    "- By default the reader will load all variables for all available jets if `variables` and `num_jets` are not specified respectively.\n",
     "\n",
     "For example to load 300 jets using three batches of size 100:\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -306,7 +317,7 @@
        "300"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +361,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -359,7 +370,7 @@
        "1000"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,16 +389,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "dtype([('deta', '<f4'), ('dphi', '<f4')])"
+       "dtype([('dphi', '<f4'), ('deta', '<f4')])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,7 +418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -529,7 +529,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -30,9 +30,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ftag.hdf5 import get_dummy_file\n",
+    "from ftag import get_mock_file\n",
     "\n",
-    "fname, f = get_dummy_file()\n",
+    "fname, f = get_mock_file()\n",
     "jets = f[\"jets\"]"
    ]
   },
@@ -529,7 +529,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -18,6 +18,14 @@ class Flavour:
     def px(self) -> str:
         return f"p{self.name.removesuffix('jets')}"
 
+    @property
+    def eff_str(self) -> str:
+        return self.label.replace("jets", "jet") + " efficiency"
+
+    @property
+    def rej_str(self) -> str:
+        return self.label.replace("jets", "jet") + " rejection"
+
     def __str__(self) -> str:
         return self.name
 

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -46,6 +46,11 @@ class FlavourContainer:
     def __getattr__(self, name) -> Flavour:
         return self[name]
 
+    def __contains__(self, flavour: str | Flavour) -> bool:
+        if isinstance(flavour, Flavour):
+            flavour = flavour.name
+        return flavour in self.flavours
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({', '.join(list(f.name for f in self))})"
 

--- a/ftag/hdf5/__init__.py
+++ b/ftag/hdf5/__init__.py
@@ -1,17 +1,13 @@
 from ftag.hdf5.h5reader import H5Reader
-from ftag.hdf5.h5utils import (
-    cast_dtype,
-    get_dtype,
-    get_dummy_file,
-    join_structured_arrays,
-)
+from ftag.hdf5.h5utils import cast_dtype, get_dtype, join_structured_arrays
 from ftag.hdf5.h5writer import H5Writer
+from ftag.mock import get_mock_file
 
 __all__ = [
     "H5Reader",
     "H5Writer",
-    "get_dummy_file",
     "get_dtype",
     "cast_dtype",
     "join_structured_arrays",
+    "get_mock_file",
 ]

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -4,7 +4,7 @@ import h5py
 import numpy as np
 from numpy.lib.recfunctions import unstructured_to_structured as u2s
 
-__all__ = ["get_dummy_file", "join_structured_arrays"]
+__all__ = ["join_structured_arrays"]
 
 
 def get_dtype(ds, variables: list[str] | None = None, precision: str | None = None) -> np.dtype:
@@ -72,58 +72,6 @@ def cast_dtype(typestr: str, precision: str) -> np.dtype:
     if precision == "full":
         return np.dtype("f4")
     raise ValueError(f"Invalid precision {precision}")
-
-
-def get_dummy_file():
-    jet_vars = [
-        "pt",
-        "eta",
-        "abs_eta",
-        "mass",
-        "HadronConeExclTruthLabelID",
-        "n_tracks",
-        "n_truth_promptLepton",
-    ]
-
-    track_vars = ["pt", "deta", "dphi", "dr"]
-
-    # settings
-    n_jets = 1000
-    n_tracks_per_jet = 40
-
-    # setup jets
-    shapes_jets = {
-        "inputs": [n_jets, len(jet_vars)],
-    }
-
-    # setup tracks
-    shapes_tracks = {
-        "inputs": [n_jets, n_tracks_per_jet, len(track_vars)],
-        "valid": [n_jets, n_tracks_per_jet],
-    }
-
-    # setup jets
-    rng = np.random.default_rng()
-    jets_dtype = np.dtype([(n, "f4") for n in jet_vars])
-    jets = u2s(rng.random(shapes_jets["inputs"]), jets_dtype)
-    jets["HadronConeExclTruthLabelID"] = np.random.choice([0, 4, 5], size=n_jets)
-    jets["pt"] *= 400e3
-    jets["eta"] = (jets["eta"] - 0.5) * 6.0
-    jets["abs_eta"] = np.abs(jets["eta"])
-
-    # setup tracks
-    tracks_dtype = np.dtype([(n, "f4") for n in track_vars])
-    tracks = u2s(rng.random(shapes_tracks["inputs"]), tracks_dtype)
-    valid = rng.random(shapes_tracks["valid"])
-    valid = valid.astype(bool).view(dtype=np.dtype([("valid", bool)]))
-    tracks = join_structured_arrays([tracks, valid])
-
-    fname = NamedTemporaryFile(suffix=".h5", dir=mkdtemp()).name
-    f = h5py.File(fname, "w")
-    f.create_dataset("jets", data=jets)
-    f.create_dataset("tracks", data=tracks)
-    f.create_dataset("flow", data=tracks)
-    return fname, f
 
 
 def join_structured_arrays(arrays: list):

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -1,8 +1,4 @@
-from tempfile import NamedTemporaryFile, mkdtemp
-
-import h5py
 import numpy as np
-from numpy.lib.recfunctions import unstructured_to_structured as u2s
 
 __all__ = ["join_structured_arrays"]
 

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+from subprocess import check_output
 
 import h5py
 import numpy as np
@@ -27,6 +28,8 @@ class H5Writer:
         self.dst.parent.mkdir(parents=True, exist_ok=True)
         self.file = h5py.File(self.dst, "w")
         self.add_attr("srcfile", str(self.src))
+        self.git_hash = check_output(["git", "rev-parse", "HEAD"]).decode("ascii").strip()
+        self.add_attr("git_hash", self.git_hash)
         for name, var in self.variables.items():
             self.create_ds(name, var)
 

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -55,7 +55,7 @@ def softmax(x, axis=None):
 def get_mock_scores(labels: np.ndarray):
     rng = np.random.default_rng()
     scores = np.zeros((len(labels), 3))
-    for label, count in zip(*np.unique(labels, return_counts=True)):
+    for label, count in zip(*np.unique(labels, return_counts=True), strict=True):
         if label == 0:
             scores[labels == label] = rng.normal(loc=[2, 0, 0], scale=1, size=(count, 3))
         elif label == 4:

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -1,0 +1,103 @@
+from tempfile import NamedTemporaryFile, mkdtemp
+
+import h5py
+import numpy as np
+from numpy.lib.recfunctions import unstructured_to_structured as u2s
+
+from ftag.hdf5 import join_structured_arrays
+
+__all__ = ["get_mock_file"]
+
+JET_VARS = [
+    "pt",
+    "eta",
+    "abs_eta",
+    "mass",
+    "pt_btagJes",
+    "eta_btagJes",
+    "n_tracks",
+    "HadronConeExclTruthLabelID",
+    "HadronConeExclTruthLabelPt",
+    "n_truth_promptLepton",
+]
+
+TRACK_VARS = [
+    "d0",
+    "z0SinTheta",
+    "dphi",
+    "deta",
+    "qOverP",
+    "IP3D_signed_d0_significance",
+    "IP3D_signed_z0_significance",
+    "phiUncertainty",
+    "thetaUncertainty",
+    "qOverPUncertainty",
+    "numberOfPixelHits",
+    "numberOfSCTHits",
+    "numberOfInnermostPixelLayerHits",
+    "numberOfNextToInnermostPixelLayerHits",
+    "numberOfInnermostPixelLayerSharedHits",
+    "numberOfInnermostPixelLayerSplitHits",
+    "numberOfPixelSharedHits",
+    "numberOfPixelSplitHits",
+    "numberOfSCTSharedHits",
+    "numberOfPixelHoles",
+    "numberOfSCTHoles",
+]
+
+
+def softmax(x, axis=None):
+    """Compute softmax values for each sets of scores in x."""
+    e_x = np.exp(x - np.max(x, axis=axis, keepdims=True))
+    return e_x / e_x.sum(axis=axis, keepdims=True)
+
+
+def get_mock_scores(labels: np.ndarray):
+    rng = np.random.default_rng()
+    scores = np.zeros((len(labels), 3))
+    for label, count in zip(*np.unique(labels, return_counts=True)):
+        if label == 0:
+            scores[labels == label] = rng.normal(loc=[2, 0, 0], scale=1, size=(count, 3))
+        elif label == 4:
+            scores[labels == label] = rng.normal(loc=[0, 1, 0], scale=2.5, size=(count, 3))
+        elif label == 5:
+            scores[labels == label] = rng.normal(loc=[0, 0, 3.5], scale=5, size=(count, 3))
+    scores = softmax(scores, axis=1)
+    cols = [f"MockTagger_p{x}" for x in ["u", "c", "b"]]
+    scores = u2s(scores, dtype=np.dtype([(name, "f4") for name in cols]))
+    return scores
+
+
+def get_mock_file(num_jets=1000, add_tagger_scores=False, tracks_name: str = "tracks"):
+    # settings
+    n_tracks_per_jet = 40
+
+    # setup jets
+    rng = np.random.default_rng()
+    jets_dtype = np.dtype([(n, "f4") for n in JET_VARS])
+    jets = u2s(rng.random((num_jets, len(JET_VARS))), jets_dtype)
+    jets["HadronConeExclTruthLabelID"] = np.random.choice([0, 4, 5], size=num_jets)
+    jets["pt"] *= 400e3
+    jets["mass"] *= 50e3
+    jets["eta"] = (jets["eta"] - 0.5) * 6.0
+    jets["abs_eta"] = np.abs(jets["eta"])
+    jets["n_truth_promptLepton"] = 0
+
+    if add_tagger_scores:
+        scores = get_mock_scores(jets["HadronConeExclTruthLabelID"])
+        jets = join_structured_arrays([jets, scores])
+
+    fname = NamedTemporaryFile(suffix=".h5", dir=mkdtemp()).name
+    f = h5py.File(fname, "w")
+    f.create_dataset("jets", data=jets)
+
+    # setup tracks
+    if tracks_name:
+        tracks_dtype = np.dtype([(n, "f4") for n in TRACK_VARS])
+        tracks = u2s(rng.random((num_jets, n_tracks_per_jet, len(TRACK_VARS))), tracks_dtype)
+        valid = rng.choice([True, False], size=(num_jets, n_tracks_per_jet))
+        valid = valid.astype(bool).view(dtype=np.dtype([("valid", bool)]))
+        tracks = join_structured_arrays([tracks, valid])
+        f.create_dataset(tracks_name, data=tracks)
+
+    return fname, f


### PR DESCRIPTION
Should go in after #9 

## Summary

This pull request introduces the following changes

* Improve mock data generation, adding tagger scores, and moving to own file
* Improve handling of reader defaults:
  * By default load/stream all jets in file
  * By default return all jet variables if none are specified


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
