### PR TITLE
Support down to python 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ATLAS FTAG Python Tools
 
 This is a collection of Python tools for working with files produced with the FTAG [ntuple dumper](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-dataset-dumper/).
+The code is intended to be used a [library](https://iscinumpy.dev/post/app-vs-library/) for other projects.
 Please see the [example notebook](ftag/example.ipynb) for usage.
 
 ## Installation

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- support python >=3.8, unpin package versions [#12](https://github.com/umami-hep/atlas-ftag-tools/pull/12)
 - improve mock data generation, update H5Reader defaults [#10](https://github.com/umami-hep/atlas-ftag-tools/pull/10)
 - add git hash to files written with H5Writer [#9](https://github.com/umami-hep/atlas-ftag-tools/pull/9)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### [Latest]
+
+### [v0.0.5]
 - support python >=3.8, unpin package versions [#12](https://github.com/umami-hep/atlas-ftag-tools/pull/12)
 - improve mock data generation, update H5Reader defaults [#10](https://github.com/umami-hep/atlas-ftag-tools/pull/10)
 - add git hash to files written with H5Writer [#9](https://github.com/umami-hep/atlas-ftag-tools/pull/9)

--- a/ftag/__init__.py
+++ b/ftag/__init__.py
@@ -1,7 +1,7 @@
 """atlas-ftag-tools - Common tools for ATLAS flavour tagging software."""
 
 
-__version__ = "v0.0.4"
+__version__ = "v0.0.5"
 
 from pathlib import Path
 

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -295,6 +295,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "And you can also access a flavour from it's definition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Flavour(name='ujets', label='Light-jets', cuts=['HadronConeExclTruthLabelID == 0'], colour='tab:green', category='single-btag')"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Flavours.from_cuts([\"HadronConeExclTruthLabelID == 5\"])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### H5Reader\n",
     "\n",
     "The `H5Reader` class allows you to read (batches) of jets from one or more HDF5 files.\n",
@@ -540,7 +568,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -16,7 +16,9 @@ class Flavour:
 
     @property
     def px(self) -> str:
-        return f"p{self.name.removesuffix('jets')}"
+        if self.name.endswith("jets"):
+            return f"p{self.name[: -len('jets')]}"
+        return f"p{self.name}"
 
     @property
     def eff_str(self) -> str:
@@ -60,3 +62,11 @@ class FlavourContainer:
 
     def by_category(self, category: str) -> FlavourContainer:
         return FlavourContainer({k: v for k, v in self.flavours.items() if v.category == category})
+
+    def from_cuts(self, cuts: list | Cuts) -> Flavour:
+        if isinstance(cuts, list):
+            cuts = Cuts.from_list(cuts)
+        for flavour in self:
+            if flavour.cuts == cuts:
+                return flavour
+        raise KeyError(f"Flavour with {cuts} not found")

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging as log
 import math
 from collections.abc import Generator
@@ -114,7 +116,7 @@ class H5Reader:
     weights: list[float] | None = None
 
     def __post_init__(self) -> None:
-        if isinstance(self.fname, str | Path):
+        if isinstance(self.fname, (str, Path)):
             self.fname = [self.fname]
 
         # calculate batch sizes
@@ -125,7 +127,7 @@ class H5Reader:
         # create readers
         self.readers = [
             H5SingleReader(fname, batch_size, self.jets_name, self.precision, self.shuffle)
-            for fname, batch_size in zip(self.fname, self.batch_sizes, strict=True)
+            for fname, batch_size in zip(self.fname, self.batch_sizes)
         ]
 
     @property

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 
 __all__ = ["join_structured_arrays"]

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import check_output

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tempfile import NamedTemporaryFile, mkdtemp
 
 import h5py
@@ -55,7 +57,7 @@ def softmax(x, axis=None):
 def get_mock_scores(labels: np.ndarray):
     rng = np.random.default_rng()
     scores = np.zeros((len(labels), 3))
-    for label, count in zip(*np.unique(labels, return_counts=True), strict=True):
+    for label, count in zip(*np.unique(labels, return_counts=True)):
         if label == 0:
             scores[labels == label] = rng.normal(loc=[2, 0, 0], scale=1, size=(count, 3))
         elif label == 4:

--- a/ftag/sample.py
+++ b/ftag/sample.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import glob
 from pathlib import Path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ license = {text = "MIT"}
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "h5py==3.8.0",
-  "numpy==1.24.*",
-  "PyYAML==6.0"
+  "h5py",
+  "numpy",
+  "PyYAML"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name="Sam Van Stroud"}, {name="Philipp Gadow"}]
 dynamic = ["version"]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 dependencies = [
   "h5py==3.8.0",
   "numpy==1.24.*",
@@ -42,6 +42,7 @@ line-length = 100
 preview = "True"
 
 [tool.ruff]
+target-version = "py38"
 select = ["I", "E", "W", "F", "B", "UP", "ARG", "SIM", "TID", "RUF", "D2", "D3", "D4"]
 ignore = ["D211", "D213", "RUF005"]
 line-length = 100


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Support python >=3.8
* Add `Flavours.from_cuts` function and usage
* prepare for v0.0.5

Relates to the following issues

* #11 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
