### PR TITLE
Add package version, not git hash to written file attrs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Replace git hash with package version in output files [#25](https://github.com/umami-hep/atlas-ftag-tools/pull/25)
 - Add tests [#24](https://github.com/umami-hep/atlas-ftag-tools/pull/24)
 
 

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from subprocess import check_output
 
 import h5py
 import numpy as np
 
+import ftag
 from ftag.hdf5 import get_dtype
 
 
@@ -30,9 +30,7 @@ class H5Writer:
         self.dst.parent.mkdir(parents=True, exist_ok=True)
         self.file = h5py.File(self.dst, "w")
         self.add_attr("srcfile", str(self.src))
-        git_hash = check_output(["git", "rev-parse", "--short", "HEAD"], cwd=Path(__file__).parent)
-        self.git_hash = git_hash.decode("ascii").strip()
-        self.add_attr("writer_hash", self.git_hash)
+        self.add_attr("writer_version", ftag.__version__)
         for name, var in self.variables.items():
             self.create_ds(name, var)
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* When installing via `pip`, the git commit check fails

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
