### PR TITLE
Fix shuffling bug in the reader

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Fix shuffling bug in H5Reader [#26](https://github.com/umami-hep/atlas-ftag-tools/pull/26)
 - Update `working_points.py` with calculation of WPs given rejections [#23](https://github.com/umami-hep/atlas-ftag-tools/pull/23)
 
 ### [v0.1.1]

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -216,8 +216,9 @@ class H5Reader:
             # combine samples and shuffle
             data = {name: np.concatenate([s[name] for s in samples]) for name in variables}
             if self.shuffle:
-                for name in variables:
-                    rng.shuffle(data[name])
+                idx = np.arange(len(data[self.jets_name]))
+                rng.shuffle(idx)
+                data = {name: array[idx] for name, array in data.items()}
 
             # select
             yield data

--- a/ftag/wps/discriminant.py
+++ b/ftag/wps/discriminant.py
@@ -12,7 +12,7 @@ def ctag_discriminant(pb, pc, pu, fb=0.2, epsilon=1e-10):
 
 
 def get_discriminant(
-    jets: np.ndarray, tagger: str, signal: Flavour, fx: float, epsilon: float = 1e-10
+    jets: np.ndarray, tagger: str, signal: Flavour | str, fx: float, epsilon: float = 1e-10
 ):
     """Calculate the b-tag or c-tag discriminant for a given tagger.
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* fixes a bug where different groups were not shuffled consistently

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
