### PR TITLE
Apply filtering to vds.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ vds <pattern> <output path>
 
 The `<pattern>` argument should be a quotes enclosed [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)), for example `"dsid/path/*.h5"`
 
+The script can also be used for the merging of samples that need to be combined in a predefined ratio. This can be done using the ```--filter-spec``` to set the dataset group and variable name e.g. ```jet:eventNumber```, and ```--filter-fraction``` to determine the sampling ratio.
+
 See `vds --help` for more options and information.
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Add option for merging MC21 ttbar samples using ```vds.py``` [#27](https://github.com/umami-hep/atlas-ftag-tools/pull/27)
 
 ### [v0.1.2]
 - Fix shuffling bug in H5Reader [#26](https://github.com/umami-hep/atlas-ftag-tools/pull/26)

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -33,7 +33,7 @@ def test_create_virtual_dataset(test_h5_files):
     layout = layouts["data"]
     assert isinstance(layout, h5py.VirtualLayout)
     assert layout.shape == (25,)
-    assert layout.dtype == np.dtype("int64")
+    assert layout.dtype == np.dtype([("var", "i8")])
 
 
 def test_create_virtual_file(test_h5_files):

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -6,7 +6,7 @@ import h5py
 import numpy as np
 import pytest
 
-from ftag.vds import create_virtual_file, get_virtual_layout
+from vds import create_virtual_file, create_virtual_dataset, create_fixed_size_chunks
 
 
 @pytest.fixture(scope="function")
@@ -17,14 +17,20 @@ def test_h5_files():
         file_paths = []
         for i in range(5):
             filename = os.path.join(tmpdir, f"test_file_{i}.h5")
+            data = np.zeros((5,), dtype=[("var", "i8")])
+            data["var"] = i
             with h5py.File(filename, "w") as f:
-                f.create_dataset("data", data=[i] * 5)
+                f.create_dataset("data", data=data)
             file_paths.append(filename)
         yield file_paths
 
 
-def test_get_virtual_layout(test_h5_files):
-    layout = get_virtual_layout(test_h5_files, "data")
+def test_create_virtual_dataset(test_h5_files):
+    groups = ["data"]
+    layouts = create_virtual_dataset(
+        test_h5_files, groups, filter_fraction=1, filtering_var_group=None, filtering_var=None
+    )
+    layout = layouts["data"]
     assert isinstance(layout, h5py.VirtualLayout)
     assert layout.shape == (25,)
     assert layout.dtype == np.dtype("int64")
@@ -36,11 +42,43 @@ def test_create_virtual_file(test_h5_files):
         # create virtual file
         output_path = Path(tmpfile.name)
         pattern = test_h5_files[0].replace("test_file_0", "test_file_*")
-        create_virtual_file(pattern, output_path, overwrite=True)
+        create_virtual_file(
+            pattern,
+            output_path,
+            overwrite=True,
+            filter_fraction=1,
+            filtering_var_group=None,
+            filtering_var=None,
+        )
         # check if file exists
         assert output_path.is_file()
         # check if file has expected content
         with h5py.File(output_path) as f:
             assert "data" in f
-            print(f["data"])
             assert len(f["data"]) == 25
+
+
+def test_create_virtual_dataset_with_filter(test_h5_files):
+    groups = ["data"]
+    layouts = create_virtual_dataset(
+        test_h5_files, groups, filter_fraction=0.5, filtering_var_group="data", filtering_var="data"
+    )
+    layout = layouts["data"]
+    assert isinstance(layout, h5py.VirtualLayout)
+    assert layout.shape[0] <= 25
+    assert layout.dtype == np.dtype("int64")
+
+
+def test_create_fixed_size_chunks():
+    indices = np.arange(10)
+    chunk_size = 3
+    expected_chunks = [
+        np.array([0, 1, 2]),
+        np.array([3, 4, 5]),
+        np.array([6, 7, 8]),
+        np.array([9]),
+    ]
+    chunks = create_fixed_size_chunks(indices, chunk_size)
+    assert len(chunks) == len(expected_chunks)
+    for chunk, expected_chunk in zip(chunks, expected_chunks):
+        assert np.array_equal(chunk, expected_chunk)

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -61,7 +61,7 @@ def test_create_virtual_file(test_h5_files):
 def test_create_virtual_dataset_with_filter(test_h5_files):
     groups = ["data"]
     layouts = create_virtual_dataset(
-        test_h5_files, groups, filter_fraction=0.5, filtering_var_group="data", filtering_var="data"
+        test_h5_files, groups, filter_fraction=0.5, filtering_var_group="data", filtering_var="var"
     )
     layout = layouts["data"]
     assert isinstance(layout, h5py.VirtualLayout)

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -26,7 +26,7 @@ def test_h5_files():
 
 
 @pytest.mark.parametrize(
-    "filter_fraction,filtering_var_group,filtering_var,expected_shape_0",
+    "filter_fraction,filtering_var_group,filtering_var,expected_shape",
     [
         (1, None, None, 25),
         (0.5, "data", "var", 25),
@@ -76,6 +76,7 @@ def test_create_virtual_file(test_h5_files):
         with h5py.File(output_path) as f:
             assert "data" in f
             assert len(f["data"]) == 25
+
 
 def test_create_fixed_size_chunks():
     indices = np.arange(10)

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -6,7 +6,7 @@ import h5py
 import numpy as np
 import pytest
 
-from vds import create_virtual_file, create_virtual_dataset, create_fixed_size_chunks
+from ftag.vds import create_fixed_size_chunks, create_virtual_dataset, create_virtual_file
 
 
 @pytest.fixture(scope="function")

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -8,7 +8,9 @@ import numpy as np
 from tqdm import tqdm
 
 
-def filter_events(fname: str, group: str, filter_fraction: float, filtering_var: str) -> np.ndarray:
+def filter_events(
+    fname: str, group: str | None, filtering_var: str | None, filter_fraction: float
+) -> np.ndarray:
     with h5py.File(fname, "r") as f:
         filtering_var_values = f[group][filtering_var][:]
         unique_values = np.unique(filtering_var_values)
@@ -31,7 +33,12 @@ def get_filtered_chunks(
 ):
     filtered_chunks = []
     for fname in fnames:
-        indices = filter_events(fname, group, filter_fraction, filtering_var)
+        indices = filter_events(
+            fname,
+            group,
+            filtering_var,
+            filter_fraction,
+        )
         fixed_size_chunks = create_fixed_size_chunks(indices)
         filtered_chunks.extend([(fname, chunk) for chunk in fixed_size_chunks])
 
@@ -56,7 +63,10 @@ def create_virtual_dataset(
     if filtering_var:
         print("Filtering events")
         filtered_chunks = get_filtered_chunks(
-            fnames, filtering_var_group, filtering_var, filter_fraction,
+            fnames,
+            filtering_var_group,
+            filtering_var,
+            filter_fraction,
         )
     else:
         filtered_chunks = [

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -8,8 +8,8 @@ import numpy as np
 
 
 def filter_events(
-    fname: str, group: str, filter_fraction: float, filtering_var: str
-) -> tuple[np.ndarray, int]:
+    fname: str, group: str, filter_fraction: float, filtering_var: str | None
+) -> np.ndarray:
     with h5py.File(fname, "r") as f:
         filtering_var = f[group][filtering_var][:]
         num_total_var = len(filtering_var)
@@ -20,23 +20,56 @@ def filter_events(
     return filtered_indices
 
 
-def get_virtual_layout(fnames: list[str], group: str, filter_fraction: float, filtering_var: str):
-    sources = []
-    total = 0
+def get_filtered_chunks(
+    fnames: list[str], group: str, filter_fraction: float, filtering_var: str | None
+):
+    filtered_chunks = []
     for fname in fnames:
         if filtering_var:
+            print("Filtering events")
             indices = filter_events(fname, group, filter_fraction, filtering_var)
-            with h5py.File(fname) as f:
-                vsource = h5py.VirtualSource(f[group], shape=(len(indices),), sel=indices)
+            print("Got indices")
         else:
-            with h5py.File(fname) as f:
-                vsource = h5py.VirtualSource(f[group])
+            with h5py.File(fname, "r") as f:
+                indices = np.arange(f[group].shape[0])
 
-        total += vsource.shape[0]
-        sources.append(vsource)
+        filtered_chunks.append((fname, indices))
 
-    # define layout of the vds
-    with h5py.File(fnames[0]) as f:
+    return filtered_chunks
+
+
+def get_contiguous_chunks(indices: np.ndarray) -> list[slice]:
+    contiguous_chunks = []
+    start = indices[0]
+    end = start
+    for i in range(1, len(indices)):
+        if indices[i] == end + 1:
+            end += 1
+        else:
+            contiguous_chunks.append(slice(start, end + 1))
+            start = indices[i]
+            end = start
+    contiguous_chunks.append(slice(start, end + 1))
+    return contiguous_chunks
+
+
+def create_virtual_dataset(
+    fnames: list[str], group: str, filter_fraction: float, filtering_var: str | None
+):
+    filtered_chunks = get_filtered_chunks(fnames, group, filter_fraction, filtering_var)
+
+    sources = []
+    total = 0
+    for fname, indices in filtered_chunks:
+        print(f"Adding {len(indices)} events from {fname}")
+        with h5py.File(fname, "r") as f:
+            src = h5py.VirtualSource(f[group])
+            contiguous_chunks = get_contiguous_chunks(indices)
+            for chunk in contiguous_chunks:
+                sources.append(src[chunk])
+                total += chunk.stop - chunk.start
+
+    with h5py.File(fnames[0], "r") as f:
         dtype = f[group].dtype
         shape = f[group].shape
     shape = (total,) + shape[1:]
@@ -57,9 +90,8 @@ def create_virtual_file(
     out_fname: Path | None = None,
     overwrite: bool = False,
     filter_fraction: float = 0.2,
-    filtering_var: str = None,
+    filtering_var: str | None = None,
 ):
-    # get list of filenames
     fnames = glob.glob(str(pattern))
     if not fnames:
         raise FileNotFoundError(f"No files matched pattern {pattern}")
@@ -79,7 +111,7 @@ def create_virtual_file(
     out_fname.parent.mkdir(exist_ok=True)
     with h5py.File(out_fname, "w") as f:
         for group in h5py.File(fnames[0]):
-            layout = get_virtual_layout(fnames, group, filter_fraction, filtering_var)
+            layout = create_virtual_dataset(fnames, group, filter_fraction, filtering_var)
             f.create_virtual_dataset(group, layout)
 
     return out_fname
@@ -98,6 +130,12 @@ def main():
         default=None,
         help="variable to use for event filtering (None for no filtering)",
     )
+    parser.add_argument(
+        "--filter-fraction",
+        type=float,
+        default=0.2,
+        help="fraction of events to keep when filtering",
+    )
     args = parser.parse_args()
 
     print(f"Globbing {args.pattern}...")
@@ -105,7 +143,7 @@ def main():
         args.pattern,
         args.output,
         overwrite=True,
-        event_ratio=(5, 1),
+        filter_fraction=args.filter_fraction,
         filtering_var=args.filtering_var,
     )
     with h5py.File(args.output) as f:

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -1,20 +1,39 @@
 from __future__ import annotations
 
 import glob
+import numpy as np
 from pathlib import Path
+from typing import Optional, Tuple
 
 import h5py
 
 
-def get_virtual_layout(fnames: list[str], group: str):
-    # get sources
+def filter_events(fname: str, group: str, event_ratio: Tuple[int, int], filtering_var: str) -> Tuple[np.ndarray, int]:
+    with h5py.File(fname, "r") as f:
+        event_numbers = f[group][filtering_var][:]
+        num_total_events = len(event_numbers)
+
+        mask = np.random.rand(num_total_events) < event_ratio[0] / sum(event_ratio)
+        filtered_indices = np.where(mask)[0]
+
+    return filtered_indices, num_total_events
+
+
+def get_virtual_layout(fnames: list[str], group: str, event_ratio: Tuple[int, int], filtering_var: Optional[str]):
     sources = []
     total = 0
     for fname in fnames:
-        with h5py.File(fname) as f:
-            vsource = h5py.VirtualSource(f[group])
-            total += vsource.shape[0]
-            sources.append(vsource)
+        if filtering_var:
+            indices, num_total_events = filter_events(fname, group, event_ratio, filtering_var)
+            with h5py.File(fname) as f:
+                vsource = h5py.VirtualSource(f[group], shape=(len(indices),), sel=indices)
+        else:
+            with h5py.File(fname) as f:
+                vsource = h5py.VirtualSource(f[group])
+                num_total_events = vsource.shape[0]
+
+        total += vsource.shape[0]
+        sources.append(vsource)
 
     # define layout of the vds
     with h5py.File(fnames[0]) as f:
@@ -27,14 +46,18 @@ def get_virtual_layout(fnames: list[str], group: str):
     idx = 0
     for source in sources:
         length = source.shape[0]
-        layout[idx : idx + length] = source
+        layout[idx: idx + length] = source
         idx += length
 
     return layout
 
 
 def create_virtual_file(
-    pattern: Path | str, out_fname: Path | None = None, overwrite: bool = False
+    pattern: Path | str,
+    out_fname: Path | None = None,
+    overwrite: bool = False,
+    event_ratio: Tuple[int, int] = (5, 1),
+    filtering_var: Optional[str] = None,
 ):
     # get list of filenames
     fnames = glob.glob(str(pattern))
@@ -56,7 +79,7 @@ def create_virtual_file(
     out_fname.parent.mkdir(exist_ok=True)
     with h5py.File(out_fname, "w") as f:
         for group in h5py.File(fnames[0]):
-            layout = get_virtual_layout(fnames, group)
+            layout = get_virtual_layout(fnames, group, event_ratio, filtering_var)
             f.create_virtual_dataset(group, layout)
 
     return out_fname
@@ -70,16 +93,16 @@ def main():
     )
     parser.add_argument("pattern", type=Path, help="quotes-enclosed glob pattern of files to merge")
     parser.add_argument("output", type=Path, help="path to output virtual file")
+    parser.add_argument("--filtering-var", default=None, help="variable to use for event filtering (None for no filtering)")
     args = parser.parse_args()
 
     print(f"Globbing {args.pattern}...")
-    create_virtual_file(args.pattern, args.output, overwrite=True)
+    create_virtual_file(args.pattern, args.output, overwrite=True, event_ratio=(5, 1), filtering_var=args.filtering_var)
     with h5py.File(args.output) as f:
         key = list(f.keys())[0]
         num = len(f[key])
     print(f"Virtual dataset '{key}' has {num:,} entries")
     print(f"Saved virtual file to {args.output.resolve()}")
-
 
 if __name__ == "__main__":
     main()

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import glob
 from pathlib import Path
-from tqdm import tqdm
 
 import h5py
 import numpy as np
+from tqdm import tqdm
 
 
 def filter_events(fname: str, group: str, filter_fraction: float, filtering_var: str) -> np.ndarray:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ requires-python = ">=3.8"
 dependencies = [
   "h5py>=3.0",  # requires numpy
   "numpy",
-  "PyYAML>=5.1"
+  "PyYAML>=5.1",
+  "tqdm"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
This pull request introduces the following changes

* For MC21 ttbar samples we merge l+jets and dilepton samples in a defined ratio of the event numbers to match the BR of the two processes. This is currently done in [this script](https://gitlab.cern.ch/atlas-flavor-tagging-tools/algorithms/umami/-/blob/master/umami/sample_merging.py). For a simple merging step with a simple cut, modifying the ```vds.py``` script to support some limited sampling seems beneficial.
* Will need to provide a short wrapper script in the umami-preprocessing repo to get exact same behaviour of current script as l+jets and dilepton samples aren't produced with exact same number of events so the exact sampling ratio won't be 20% and will depend on those differences - with files I am testing ratio is 0.203.

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
