### PR TITLE
Draft: Sample class fix

### DIFF
--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -27,6 +27,9 @@ class H5SingleReader:
     def __post_init__(self) -> None:
         self.sample = Sample(self.fname)
         self.fname = self.sample.virtual_file()
+        if len(self.fname) != 1:
+            raise ValueError("H5SingleReader should only read a single file")
+        self.fname = self.fname[0]
 
     @cached_property
     def num_jets(self) -> int:

--- a/ftag/sample.py
+++ b/ftag/sample.py
@@ -23,23 +23,18 @@ class Sample:
             raise FileNotFoundError(f"The following files do not exist: {missing}")
 
     @property
-    def path(self) -> Path | tuple[Path]:
+    def path(self) -> tuple[Path]:
+        pattern_tuple = self.pattern if isinstance(self.pattern, tuple) else (self.pattern,)
         if self.ntuple_dir is not None:
-            if isinstance(self.pattern, tuple):
-                return tuple(Path(self.ntuple_dir, p) for p in self.pattern)
-            return Path(self.ntuple_dir, self.pattern)
-        if isinstance(self.pattern, tuple):
-            return tuple(Path(p) for p in self.pattern)
-        return Path(self.pattern)
+            return tuple(Path(self.ntuple_dir, p) for p in pattern_tuple)
+        return tuple(Path(p) for p in pattern_tuple)
 
     @property
-    def files(self) -> list[str]:
-        if isinstance(self.path, tuple):
-            files = []
-            for p in self.path:
-                files += glob.glob(str(p)) if "*" in str(p) else [str(p)]
-                return files
-        return glob.glob(str(self.path)) if "*" in str(self.path) else [str(self.path)]
+    def files(self) -> list[str]:    
+        files = []
+        for p in self.path:
+            files += glob.glob(str(p)) if "*" in str(p) else [str(p)]
+        return files
 
     @property
     def num_files(self) -> int:
@@ -70,11 +65,11 @@ class Sample:
         hashes = [remove_suffix(dsid.split(".")[7], "_output") for dsid in self.dsid]
         return list(set(hashes))
 
-    def virtual_file(self, **kwargs) -> Path | str:
-        # FIXME: self.path can be a tuple here
-        if "*" in str(self.path):
-            return create_virtual_file(self.path, **kwargs)
-        return self.path
+    def virtual_file(self, **kwargs) -> list[Path | str]:
+        virtual_file_paths = []
+        for p in self.path:
+                virtual_file_paths.append(create_virtual_file(p, **kwargs) if "*" in str(p) else p)
+        return virtual_file_paths
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
Small fix to the `Sample` class, allowing `patter` to be a list of paths rather than a single one. This was removed in [PR #15](https://github.com/umami-hep/atlas-ftag-tools/pull/15/files), when `Sample` was refactored.

Now `self.path` is always a `tuple[str]`.

To-do: potentially fix some tests, I haven't checked them all but at least [this one](https://github.com/umami-hep/atlas-ftag-tools/blob/main/ftag/tests/test_sample.py#L72) will fail, since `virtual_file()` output should be `list[Path]`, not just `Path`.