### PR TITLE
Update cuts.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### [Latest]
-
+- Update cuts to allow larger possible max integer selection [#29](https://github.com/umami-hep/atlas-ftag-tools/pull/29)
 - Add codes to copy attributes from source files to the target file [#20](https://github.com/umami-hep/atlas-ftag-tools/pull/20/)
 
 ### [v0.1.3]

--- a/ftag/cuts.py
+++ b/ftag/cuts.py
@@ -20,7 +20,7 @@ OPERATORS = {
     "notin": lambda x, y: ~np.isin(x, y),
 }
 
-for i in range(2, 20):
+for i in range(2, 101):
     OPERATORS[f"%{i}=="] = functools.partial(lambda x, y, i: (x % i) == y, i=i)
     OPERATORS[f"%{i}<="] = functools.partial(lambda x, y, i: (x % i) <= y, i=i)
     OPERATORS[f"%{i}>="] = functools.partial(lambda x, y, i: (x % i) >= y, i=i)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update the possible max integer cut. Current value of 20 (exclusive, so 19 really) doesn't cover the ```n_tracks``` cut we apply in Salt's compare models script and potentially in other places too.
*

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
