### PR TITLE
Check for -1 jets and add new top label

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Check for `num_jets` of `-1` [#31](https://github.com/umami-hep/atlas-ftag-tools/pull/31)
 - Update test for vds.py [#30](https://github.com/umami-hep/atlas-ftag-tools/pull/30)
 - Update cuts to allow larger possible max integer selection [#29](https://github.com/umami-hep/atlas-ftag-tools/pull/29)
 - Add codes to copy attributes from source files to the target file [#20](https://github.com/umami-hep/atlas-ftag-tools/pull/20/)

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### [Latest]
-- Check for `num_jets` of `-1` [#31](https://github.com/umami-hep/atlas-ftag-tools/pull/31)
+- Check for `num_jets` of `-1` and add new inclusive top category [#31](https://github.com/umami-hep/atlas-ftag-tools/pull/31)
 - Update test for vds.py [#30](https://github.com/umami-hep/atlas-ftag-tools/pull/30)
 - Update cuts to allow larger possible max integer selection [#29](https://github.com/umami-hep/atlas-ftag-tools/pull/29)
 - Add codes to copy attributes from source files to the target file [#20](https://github.com/umami-hep/atlas-ftag-tools/pull/20/)

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -57,12 +57,16 @@
   label: Hcc
   cuts: ["R10TruthLabel_R22v1 == 12"]
   colour: "#B45F06"
-  category: xbb
+  category: xbb 
 - name: top
   label: Top
   cuts: ["R10TruthLabel_R22v1 == 1"]
   colour: "#A300A3"
   category: xbb
+- name:
+  label: inclusive_top
+  label: Inclusive Top
+  cuts: ["R10TruthLabel_R22v1 in (1,6,7)"]
 - name: qcd
   label: QCD
   cuts: ["R10TruthLabel_R22v1 == 10"]

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -63,8 +63,7 @@
   cuts: ["R10TruthLabel_R22v1 == 1"]
   colour: "#A300A3"
   category: xbb
-- name:
-  label: inclusive_top
+- name: inclusive_top
   label: Inclusive Top
   cuts: ["R10TruthLabel_R22v1 in (1,6,7)"]
   colour: "#A300A3"

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -57,7 +57,7 @@
   label: Hcc
   cuts: ["R10TruthLabel_R22v1 == 12"]
   colour: "#B45F06"
-  category: xbb 
+  category: xbb
 - name: top
   label: Top
   cuts: ["R10TruthLabel_R22v1 == 1"]
@@ -67,6 +67,8 @@
   label: inclusive_top
   label: Inclusive Top
   cuts: ["R10TruthLabel_R22v1 in (1,6,7)"]
+  colour: "#A300A3"
+  category: xbb
 - name: qcd
   label: QCD
   cuts: ["R10TruthLabel_R22v1 == 10"]

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -228,6 +228,8 @@ class H5Reader:
     def load(
         self, variables: dict | None = None, num_jets: int | None = None, cuts: Cuts | None = None
     ) -> dict:
+        if num_jets == -1:
+            num_jets = self.num_jets
         if variables is None:
             variables = {self.jets_name: None}
         data: dict[str, list] = {name: [] for name in variables}

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -58,3 +58,12 @@ def test_H5Reader(num, length):
         if num > 1:
             corr = np.corrcoef(data["jets"]["x"], data["tracks"]["a"][:, 0])
             np.testing.assert_allclose(corr, 1)
+
+    # testing load method
+    loaded_data = reader.load(num_jets=-1)
+
+    # check if -1 is passed, all data is loaded
+    assert loaded_data["jets"].shape == (num * length,)
+
+    # check not passing variables explicitly uses all variables
+    assert len(loaded_data["jets"].dtype.names) == 2


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* In some downstream use cases we use -1 to represent take all jets in the sample, if this is passed directly to the `H5Reader` this causes issues. Of course proper usage would be to not pass the ```num_jets``` argument if using -1 elsewhere but an extra safety check doesn't hurt.
*

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
