### PR TITLE
Fix to Sample class (again)

### DIFF
--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -26,9 +26,10 @@ class H5SingleReader:
 
     def __post_init__(self) -> None:
         self.sample = Sample(self.fname)
-        if len(self.sample.virtual_file()) != 1:
+        fname = self.sample.virtual_file()
+        if len(fname) != 1:
             raise ValueError("H5SingleReader should only read a single file")
-        self.fname = self.sample.virtual_file()[0]
+        self.fname = fname[0]
 
     @cached_property
     def num_jets(self) -> int:

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -141,6 +141,7 @@ class H5Reader:
     shuffle: bool = True
     weights: list[float] | None = None
     do_remove_inf: bool = False
+    equal_jets_from_samples: bool = True
 
     def __post_init__(self) -> None:
         if isinstance(self.fname, (str, Path)):
@@ -208,7 +209,7 @@ class H5Reader:
 
         rng = np.random.default_rng(42)
         while True:
-            # yeild from each stream
+            # yield from each stream
             samples = []
             streams_done = [False] * len(streams)  # Track which streams have been exhausted
             for i, stream in enumerate(streams):
@@ -217,6 +218,8 @@ class H5Reader:
                         samples.append(next(stream))
                     except StopIteration:
                         streams_done[i] = True
+                        if self.equal_jets_from_samples:
+                            return
                 if all(streams_done):
                     return
 
@@ -246,6 +249,9 @@ class H5Reader:
 
     def estimate_available_jets(self, cuts: Cuts, num: int = 1_000_000) -> int:
         """Estimate the number of jets available after selection cuts, rounded down."""
+        # And equal_jets_from_samples flag here
+        # to change how to estimate the number of available jets
+        # TODO: Not implemented yet!
         all_jets = self.load({self.jets_name: cuts.variables}, num)[self.jets_name]
         estimated_num_jets = len(cuts(all_jets).values) / len(all_jets) * self.num_jets
         return math.floor(estimated_num_jets / 1_000) * 1_000

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -262,9 +262,9 @@ class H5Reader:
         However, the remaining jets after cuts is estimated from all files.
         """
         all_jets = self.load({self.jets_name: cuts.variables}, num)[self.jets_name]
-        est_total_jets = {
-            True: min(r.num_jets for r in self.readers) * len(self.readers),
-            False: self.num_jets,
-        }[self.equal_jets]
+        if self.equal_jets:
+            est_total_jets = min(r.num_jets for r in self.readers) * len(self.readers)
+        else:
+            est_total_jets = self.num_jets
         estimated_num_jets = len(cuts(all_jets).values) / len(all_jets) * est_total_jets
         return math.floor(estimated_num_jets / 1_000) * 1_000

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -210,10 +210,14 @@ class H5Reader:
         while True:
             # yeild from each stream
             samples = []
-            for stream in streams:
-                try:
-                    samples.append(next(stream))
-                except StopIteration:
+            streams_done = [False] * len(streams)  # Track which streams have been exhausted
+            for i, stream in enumerate(streams):
+                if not streams_done[i]:
+                    try:
+                        samples.append(next(stream))
+                    except StopIteration:
+                        streams_done[i] = True
+                if all(streams_done):
                     return
 
             # combine samples and shuffle

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -144,6 +144,14 @@ class H5Reader:
     equal_jets: bool = True
 
     def __post_init__(self) -> None:
+        if not self.equal_jets:
+            log.warn(
+                "equal_jets is set to False, "
+                "which will result in different number of jets taken from samples. "
+                "Be aware that this can affect the resampling, "
+                "so make sure you know what you are doing."
+            )
+
         if isinstance(self.fname, (str, Path)):
             self.fname = [self.fname]
 

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -141,7 +141,7 @@ class H5Reader:
     shuffle: bool = True
     weights: list[float] | None = None
     do_remove_inf: bool = False
-    equal_jets_from_samples: bool = True
+    equal_jets: bool = True
 
     def __post_init__(self) -> None:
         if isinstance(self.fname, (str, Path)):
@@ -218,7 +218,7 @@ class H5Reader:
                         samples.append(next(stream))
                     except StopIteration:
                         streams_done[i] = True
-                        if self.equal_jets_from_samples:
+                        if self.equal_jets:
                             return
                 if all(streams_done):
                     return
@@ -249,7 +249,7 @@ class H5Reader:
 
     def estimate_available_jets(self, cuts: Cuts, num: int = 1_000_000) -> int:
         """Estimate the number of jets available after selection cuts, rounded down."""
-        # And equal_jets_from_samples flag here
+        # And equal_jets flag here
         # to change how to estimate the number of available jets
         # TODO: Not implemented yet!
         all_jets = self.load({self.jets_name: cuts.variables}, num)[self.jets_name]

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -13,23 +13,27 @@ from ftag.sample import Sample
 # parameterise the test
 @pytest.mark.parametrize("num", [1, 2, 3])
 @pytest.mark.parametrize("length", [200, 301])
-def test_H5Reader(num, length):
+@pytest.mark.parametrize("equal_jets", [True, False])
+def test_H5Reader(num, length, equal_jets):
+    # calculate all possible effective batch sizes, from single file batch sizes and remainders
     batch_size = 100
-    effective_bs = batch_size // num * num
-    remainder = length % effective_bs * num
+    effective_bs_file = batch_size // num
+    remainders = [(length * n) % effective_bs_file for n in range(num + 1)]
+    effective_bs_options = [effective_bs_file * n + r for n in range(num + 1) for r in remainders]
+    effective_bs_options = [x for x in effective_bs_options if x <= batch_size][1:]
 
-    # create test files
+    # create test files (of different lengths)
     tmpdirs = []
     for i in range(num):
         fname = NamedTemporaryFile(suffix=".h5", dir=mkdtemp()).name
         tmpdirs.append(Path(fname).parent)
 
         with h5py.File(fname, "w") as f:
-            data = i * np.ones((length, 2))
+            data = i * np.ones((length * (i + 1), 2))
             data = u2s(data, dtype=[("x", "f4"), ("y", "f4")])
             f.create_dataset("jets", data=data)
 
-            data = i * np.ones((length, 40, 2))
+            data = i * np.ones((length * (i + 1), 40, 2))
             data = u2s(data, dtype=[("a", "f4"), ("b", "f4")])
             f.create_dataset("tracks", data=data)
 
@@ -37,17 +41,18 @@ def test_H5Reader(num, length):
     sample = Sample([f"{x}/*.h5" for x in tmpdirs], name="test")
 
     # test reading from multiple paths
-    reader = H5Reader(sample.path, batch_size=batch_size)
-    assert reader.num_jets == num * length
+    reader = H5Reader(sample.path, batch_size=batch_size, equal_jets=equal_jets)
+    assert reader.num_jets == num * (num + 1) / 2 * length
     variables = {"jets": ["x", "y"], "tracks": None}
     for data in reader.stream(variables=variables):
         assert "jets" in data
-        assert data["jets"].shape == (effective_bs,) or data["jets"].shape == (remainder,)
+        assert data["jets"].shape in [(effective_bs,) for effective_bs in effective_bs_options]
         assert len(data["jets"].dtype.names) == 2
         assert "tracks" in data
-        assert data["tracks"].shape == (effective_bs, 40) or data["tracks"].shape == (remainder, 40)
+        assert data["tracks"].shape in [(effective_bs, 40) for effective_bs in effective_bs_options]
         assert len(data["tracks"].dtype.names) == 2
-        assert (np.unique(data["jets"]["x"]) == np.array(list(range(num)))).all()
+        if equal_jets:  # if equal_jets is off, batches won't necessarily have data from all files
+            assert (np.unique(data["jets"]["x"]) == np.array(list(range(num)))).all()
 
         # check that the tracks are correctly matched to the jets
         for i in range(num):
@@ -56,14 +61,19 @@ def test_H5Reader(num, length):
             assert (jet == trk).all()
 
         if num > 1:
-            corr = np.corrcoef(data["jets"]["x"], data["tracks"]["a"][:, 0])
-            np.testing.assert_allclose(corr, 1)
+            if len(np.unique(data["jets"]["x"])) == 1:
+                np.testing.assert_array_equal(data["jets"]["x"], data["tracks"]["a"][:, 0])
+            else:
+                corr = np.corrcoef(data["jets"]["x"], data["tracks"]["a"][:, 0])
+                np.testing.assert_allclose(corr, 1)
 
     # testing load method
     loaded_data = reader.load(num_jets=-1)
 
     # check if -1 is passed, all data is loaded
-    assert loaded_data["jets"].shape == (num * length,)
+    if not equal_jets:
+        expected_shape = (num * (num + 1) / 2 * length,)
+        assert loaded_data["jets"].shape == expected_shape
 
     # check not passing variables explicitly uses all variables
     assert len(loaded_data["jets"].dtype.names) == 2


### PR DESCRIPTION
The previous fix introduced a problem (or rather highlighted an existing one) where when reading multiple samples in different streams, when one runs out it stops. While is is the intended behaviour in some cases, there are two problems:

1. Sometimes we want as many stats as possbile, rather than drawing equally from each sample.
2. Number of jets estimation takes an average of all samples, meaning if their number is unbalanced, it overestimates the number of available jets.

My suggestion is to modify H5Reader to add a flag `equal_jets_from_samples` that would control, which behaviour we want.

TODO: modify `estimate_available_jets` to output the available number of jets depending on the flag.


This PR is related to [the other one](https://github.com/umami-hep/umami-preprocessing/pull/4) in umami-preprocessing