### PR TITLE
Setting num_jets to maximum available if too large

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Setting num_jets to maximum available if too large [#34](https://github.com/umami-hep/atlas-ftag-tools/pull/34)
+
 ### [v0.1.4]
 - Check for `num_jets` of `-1` and add new inclusive top category [#31](https://github.com/umami-hep/atlas-ftag-tools/pull/31)
 - Update test for vds.py [#30](https://github.com/umami-hep/atlas-ftag-tools/pull/30)

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -64,14 +64,20 @@ class H5SingleReader:
         return {name: array[keep_idx] for name, array in data.items()}
 
     def stream(
-        self, variables: dict | None = None, num_jets: int | None = None, cuts: Cuts | None = None
+        self,
+        variables: dict | None = None,
+        num_jets: int | None = None,
+        cuts: Cuts | None = None,
     ) -> Generator:
         if num_jets is None:
             num_jets = self.num_jets
+
         if num_jets > self.num_jets:
-            raise ValueError(
-                f"{num_jets:,} jets requested but only {self.num_jets:,} available in {self.fname}"
+            log.warn(
+                f"{num_jets:,} jets requested but only {self.num_jets:,} available in {self.fname}."
+                " Set to maximum available number!"
             )
+            num_jets = self.num_jets
 
         if variables is None:
             variables = {self.jets_name: None}
@@ -173,7 +179,10 @@ class H5Reader:
         return dtypes
 
     def stream(
-        self, variables: dict | None = None, num_jets: int | None = None, cuts: Cuts | None = None
+        self,
+        variables: dict | None = None,
+        num_jets: int | None = None,
+        cuts: Cuts | None = None,
     ) -> Generator:
         """Generate batches of selected jets.
 
@@ -191,10 +200,14 @@ class H5Reader:
         Generator
             Generator of batches of selected jets.
         """
+        # Check if number of jets is given, if not, set to maximum available
         if num_jets is None:
             num_jets = self.num_jets
+
+        # Check if variables if given, if not, set to all
         if variables is None:
             variables = {self.jets_name: None}
+
         if self.jets_name not in variables or variables[self.jets_name] is not None:
             jet_vars = variables.get(self.jets_name, [])
             variables[self.jets_name] = list(jet_vars) + (cuts.variables if cuts else [])
@@ -226,7 +239,10 @@ class H5Reader:
             yield data
 
     def load(
-        self, variables: dict | None = None, num_jets: int | None = None, cuts: Cuts | None = None
+        self,
+        variables: dict | None = None,
+        num_jets: int | None = None,
+        cuts: Cuts | None = None,
     ) -> dict:
         if num_jets == -1:
             num_jets = self.num_jets


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Set the `num_jets` to the maximum available in the H5SingleReader to encounter issue when to many jets are requested.

Relates to the following issues

* Closes #22

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
