### PR TITLE
Changing labels of Hbb and Hcc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Changing labels of Hbb and Hcc [#35](https://github.com/umami-hep/atlas-ftag-tools/pull/35)
 - Setting num_jets to maximum available if too large [#34](https://github.com/umami-hep/atlas-ftag-tools/pull/34)
 
 ### [v0.1.4]

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -49,12 +49,12 @@
 
 # Xbb tagging
 - name: hbb
-  label: Hbb
+  label: $H \rightarrow b\bar{b}$
   cuts: ["R10TruthLabel_R22v1 == 11"]
   colour: tab:blue
   category: xbb
 - name: hcc
-  label: Hcc
+  label: $H \rightarrow c\bar{c}$
   cuts: ["R10TruthLabel_R22v1 == 12"]
   colour: "#B45F06"
   category: xbb


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Changing labels of Hbb and Hcc to `$H \rightarrow b\bar{b}$` and `$H \rightarrow c\bar{c}$`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
