### PR TITLE
Update top label in flavours.yaml

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Update top labelling names [#39](https://github.com/umami-hep/atlas-ftag-tools/pulls)
 
 
 ### [v0.1.5]

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### [Latest]
-- Update top labelling names [#39](https://github.com/umami-hep/atlas-ftag-tools/pulls)
+- Update top labelling names [#39](https://github.com/umami-hep/atlas-ftag-tools/pull/39)
 
 
 ### [v0.1.5]

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -58,12 +58,12 @@
   cuts: ["R10TruthLabel_R22v1 == 12"]
   colour: "#B45F06"
   category: xbb
-- name: top
-  label: Top
+- name: tqqb
+  label: Fully Contained Top
   cuts: ["R10TruthLabel_R22v1 == 1"]
   colour: "#A300A3"
   category: xbb
-- name: inclusive_top
+- name: top
   label: Inclusive Top
   cuts: ["R10TruthLabel_R22v1 in (1,6,7)"]
   colour: "#A300A3"


### PR DESCRIPTION
## Summary
`inclusive_top` wasn't a good name for the updated top label as the model output scores for those models have `pinclusive_top` which is far too verbose. So changing the original top label to `tqqb` to be more specific of what it includes and renaming the inclusive top label to just `top`


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
