### PR TITLE
Draft: Add on the fly variable renaming and transformation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Add on the fly variable renaming and data transforms [#44](https://github.com/umami-hep/atlas-ftag-tools/pull/44)
 - Unfreeze flavour class to allow for on the fly modification [#43](https://github.com/umami-hep/atlas-ftag-tools/pull/43)
 - Update linters [#41](https://github.com/umami-hep/atlas-ftag-tools/pull/41)
 

--- a/ftag/__init__.py
+++ b/ftag/__init__.py
@@ -9,6 +9,7 @@ from ftag.cuts import Cuts
 from ftag.flavour import Flavour, Flavours
 from ftag.mock import get_mock_file
 from ftag.sample import Sample
+from ftag.transform import Transform
 from ftag.wps.discriminant import get_discriminant
 from ftag.wps.working_points import get_working_points
 
@@ -17,6 +18,7 @@ __all__ = [
     "Flavour",
     "Flavours",
     "Sample",
+    "Transform",
     "hdf5",
     "get_mock_file",
     "get_discriminant",

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -548,6 +548,70 @@
     "import h5py\n",
     "assert (h5py.File(fname)[\"jets\"][:] == h5py.File(out_fname)[\"jets\"][:]).all()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Data Transform\n",
+    "\n",
+    "The `transform.py` module allows for data to be transformed as it is loaded.\n",
+    "Three operations are supported:\n",
+    "\n",
+    "- Renaming variables\n",
+    "- Mapping integer values\n",
+    "- Functional transforms on floating point values\n",
+    "\n",
+    "See below for an example. First, we can make a transform config (which in this case just log scales the jet pt)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform_config = {\n",
+    "    \"floats_map\": {\n",
+    "        \"jets\": {\n",
+    "            \"pt\": \"log\",\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "from ftag.transform import Transform\n",
+    "transform = Transform(**transform_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This object can be passed to the `H5Reader` constructor.\n",
+    "The resulting object will return transformed values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(6.871671, 12.899197)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reader = H5Reader(fname, batch_size=100, transform=transform)\n",
+    "data = reader.load({\"jets\": [\"pt\", \"eta\"]}, num_jets=300)\n",
+    "data[\"jets\"]['pt'].min(), data[\"jets\"]['pt'].max()"
+   ]
   }
  ],
  "metadata": {

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -523,20 +523,7 @@
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "'tracks'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[22], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfor\u001b[39;00m batch \u001b[39min\u001b[39;00m reader\u001b[39m.\u001b[39mstream(num_jets\u001b[39m=\u001b[39m\u001b[39m1000\u001b[39m):\n\u001b[0;32m----> 2\u001b[0m     writer\u001b[39m.\u001b[39;49mwrite(batch)\n\u001b[1;32m      3\u001b[0m writer\u001b[39m.\u001b[39mclose()\n",
-      "File \u001b[0;32m/unix/atlastracking/svanstroud/upp/atlas-ftag-tools/ftag/hdf5/h5writer.py:88\u001b[0m, in \u001b[0;36mH5Writer.write\u001b[0;34m(self, data)\u001b[0m\n\u001b[1;32m     86\u001b[0m high \u001b[39m=\u001b[39m low \u001b[39m+\u001b[39m \u001b[39mlen\u001b[39m(idx)\n\u001b[1;32m     87\u001b[0m \u001b[39mfor\u001b[39;00m group \u001b[39min\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mgroups:\n\u001b[0;32m---> 88\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfile[group][low:high] \u001b[39m=\u001b[39m data[group]\n\u001b[1;32m     89\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mnum_written \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39mlen\u001b[39m(idx)\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'tracks'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for batch in reader.stream(num_jets=1000):\n",
     "    writer.write(batch)\n",
@@ -554,7 +541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -250,7 +250,7 @@
     {
      "data": {
       "text/plain": [
-       "FlavourContainer(hbb, hcc, top, qcd)"
+       "FlavourContainer(hbb, hcc, top, inclusive_top, qcd)"
       ]
      },
      "execution_count": 12,
@@ -489,7 +489,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `H5Writer` class complents the reader class by allowing you to easily write batches of jetes to a target file."
+    "The `H5Writer` class complents the reader class by allowing you to easily write batches of jets to a target file."
    ]
   },
   {
@@ -501,12 +501,12 @@
     "from ftag.hdf5 import H5Writer\n",
     "from tempfile import NamedTemporaryFile\n",
     "\n",
+    "reader = H5Reader(fname, batch_size=100, shuffle=False)\n",
     "out_fname = NamedTemporaryFile(suffix=\".h5\").name\n",
-    "variables = {\"jets\": reader.dtypes['jets'].names}\n",
     "writer = H5Writer(\n",
-    "    src=fname,\n",
+    "    reader=reader,\n",
     "    dst=out_fname,\n",
-    "    variables=variables,\n",
+    "    groups=[\"jets\"],\n",
     "    num_jets=1000,\n",
     "    shuffle=False,\n",
     ")"
@@ -523,11 +523,22 @@
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'tracks'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[22], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mfor\u001b[39;00m batch \u001b[39min\u001b[39;00m reader\u001b[39m.\u001b[39mstream(num_jets\u001b[39m=\u001b[39m\u001b[39m1000\u001b[39m):\n\u001b[0;32m----> 2\u001b[0m     writer\u001b[39m.\u001b[39;49mwrite(batch)\n\u001b[1;32m      3\u001b[0m writer\u001b[39m.\u001b[39mclose()\n",
+      "File \u001b[0;32m/unix/atlastracking/svanstroud/upp/atlas-ftag-tools/ftag/hdf5/h5writer.py:88\u001b[0m, in \u001b[0;36mH5Writer.write\u001b[0;34m(self, data)\u001b[0m\n\u001b[1;32m     86\u001b[0m high \u001b[39m=\u001b[39m low \u001b[39m+\u001b[39m \u001b[39mlen\u001b[39m(idx)\n\u001b[1;32m     87\u001b[0m \u001b[39mfor\u001b[39;00m group \u001b[39min\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mgroups:\n\u001b[0;32m---> 88\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mfile[group][low:high] \u001b[39m=\u001b[39m data[group]\n\u001b[1;32m     89\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mnum_written \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39mlen\u001b[39m(idx)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'tracks'"
+     ]
+    }
+   ],
    "source": [
-    "reader = H5Reader(fname, batch_size=100, shuffle=False)\n",
-    "stream = reader.stream(variables, num_jets=1000)\n",
-    "for batch in stream:\n",
+    "for batch in reader.stream(num_jets=1000):\n",
     "    writer.write(batch)\n",
     "writer.close()"
    ]
@@ -543,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +579,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -15,7 +15,7 @@ def remove_suffix(string: str, suffix: str) -> str:
     return string
 
 
-@dataclass
+@dataclass(frozen=True)
 class Flavour:
     name: str
     label: str

--- a/ftag/hdf5/h5move.py
+++ b/ftag/hdf5/h5move.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import h5py
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(description="Move/rename a dataset in an h5 file")
+    parser.add_argument("fname", type=Path, help="path to h5 file")
+    parser.add_argument(
+        "src", type=str, help="path within h5 file to source dataset, starts with '/'"
+    )
+    parser.add_argument(
+        "dst", type=str, help="path within h5 file to destination dataset, starts with '/'"
+    )
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+    print(f"Moving {args.src} to {args.dst} in {args.fname}")
+    f = h5py.File(args.fname, "a")
+    f.move(args.src, args.dst)
+    f.close()

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -44,7 +44,7 @@ class H5SingleReader:
             return obj.attrs[name]
 
     def empty(self, ds: h5py.Dataset, variables: list[str]) -> np.ndarray:
-        return np.array(0, dtype=get_dtype(ds, variables, self.precision))
+        return np.array(0, dtype=get_dtype(ds, variables, self.precision, transform=self.transform))
 
     def read_chunk(self, ds: h5py.Dataset, array: np.ndarray, low: int) -> np.ndarray:
         high = min(low + self.batch_size, self.num_jets)

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -57,9 +57,10 @@ class H5SingleReader:
         keep_idx = np.full(len(data[self.jets_name]), True)
         for name, array in data.items():
             for var in array.dtype.names:
-                isinf = np.isinf(array[var])
-                keep_idx = keep_idx & ~isinf.any(axis=-1)
-                if num_inf := isinf.sum():
+                notinf = ~np.isinf(array[var])
+                notinf = notinf if name == self.jets_name else notinf.any(axis=-1)
+                keep_idx = keep_idx & notinf
+                if num_inf := ~notinf.sum():
                     log.warning(
                         f"{num_inf} inf values detected for variable {var} in"
                         f" {name} array. Removing the affected jets."

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -88,6 +88,7 @@ class H5SingleReader:
         total = 0
         rng = np.random.default_rng(42)
         with h5py.File(self.fname) as f:
+            arrays = {name: self.empty(f[name], var) for name, var in variables.items()}
             data = {name: self.empty(f[name], var) for name, var in variables.items()}
 
             # get indices
@@ -98,7 +99,7 @@ class H5SingleReader:
             # loop over batches and read file
             for low in indices:
                 for name in variables:
-                    data[name] = self.read_chunk(f[name], data[name], low)
+                    data[name] = self.read_chunk(f[name], arrays[name], low)
 
                 # apply selections
                 if cuts:

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -57,10 +57,10 @@ class H5SingleReader:
         keep_idx = np.full(len(data[self.jets_name]), True)
         for name, array in data.items():
             for var in array.dtype.names:
-                notinf = ~np.isinf(array[var])
-                notinf = notinf if name == self.jets_name else notinf.any(axis=-1)
-                keep_idx = keep_idx & notinf
-                if num_inf := ~notinf.sum():
+                isinf = np.isinf(array[var])
+                isinf = isinf if name == self.jets_name else isinf.any(axis=-1)
+                keep_idx = keep_idx & ~isinf
+                if num_inf := isinf.sum():
                     log.warning(
                         f"{num_inf} inf values detected for variable {var} in"
                         f" {name} array. Removing the affected jets."

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -205,7 +205,10 @@ class H5Reader:
         dtypes = {}
         with h5py.File(self.files[0]) as f:
             for key in f:
-                dtypes[key] = f[key].dtype
+                dtype = f[key].dtype
+                if self.transform:
+                    dtype = self.transform.map_dtype(key, dtype)
+                dtypes[key] = dtype
         return dtypes
 
     def stream(

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -14,8 +14,8 @@ from ftag.hdf5.h5reader import H5Reader
 class H5Writer:
     reader: H5Reader
     dst: Path | str
-    num_jets: int
     groups: list[str]
+    num_jets: int
     jets_name: str = "jets"
     add_flavour_label: bool = False
     compression: str = "lzf"

--- a/ftag/tests/hdf5/test_h5move.py
+++ b/ftag/tests/hdf5/test_h5move.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import h5py
+import pytest
+
+from ftag import get_mock_file
+from ftag.hdf5.h5move import main, parse_args
+
+
+@pytest.fixture
+def get_fname():
+    return get_mock_file()[0]
+
+
+def test_parse_args():
+    # Test for the parse_args function
+    args = ["/path/to/file.h5", "/source/dataset", "/destination/dataset"]
+    parsed_args = parse_args(args)
+    assert parsed_args.fname == Path("/path/to/file.h5")
+    assert parsed_args.src == "/source/dataset"
+    assert parsed_args.dst == "/destination/dataset"
+
+
+def test_main(get_fname):
+    fname = get_fname
+    old_data = h5py.File(fname)["/jets"][:]
+
+    main([fname, "/jets", "/jets_new"])
+
+    f = h5py.File(fname)
+    assert "/jets" not in f
+    assert "/jets_new" in f
+    assert all(f["/jets_new"][:] == old_data)
+    f.close()

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -6,9 +6,11 @@ import numpy as np
 import pytest
 from numpy.lib.recfunctions import unstructured_to_structured as u2s
 
+from ftag import get_mock_file
 from ftag.cuts import Cuts
 from ftag.hdf5.h5reader import H5Reader
 from ftag.sample import Sample
+from ftag.transform import Transform
 
 
 # parameterise the test
@@ -134,3 +136,21 @@ def test_estimate_available_jets(equal_jets, cuts_list):
 
     # These values should be approximately correct, but with the given random seed they are exact
     assert estimated_num_jets == actual_available_jets
+
+
+def test_reader_transform():
+    fname, f = get_mock_file()
+
+    transform = Transform(
+        {
+            "jets": {
+                "pt": "pt_new",
+                "silent": "silent",
+            }
+        }
+    )
+
+    reader = H5Reader(fname, transform=transform)
+    data = reader.load(num_jets=10)
+
+    assert "pt_new" in data["jets"].dtype.names

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -150,7 +150,7 @@ def test_reader_transform():
         }
     )
 
-    reader = H5Reader(fname, transform=transform)
+    reader = H5Reader(fname, transform=transform, batch_size=1)
     data = reader.load(num_jets=10)
 
     assert "pt_new" in data["jets"].dtype.names

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -183,6 +183,14 @@ def test_remove_inf_with_inf_values(singlereader):
     assert len(result["jets"]) == 99
     assert len(result["tracks"]) == 99
 
+    _, f = get_mock_file()
+    data = {"jets": f["jets"][:100], "tracks": f["tracks"][:100]}
+    data["tracks"]["d0"] = 1
+    data["tracks"]["d0"][0] = np.inf
+    result = singlereader.remove_inf(data)
+    assert len(result["jets"]) == 99
+    assert len(result["tracks"]) == 99
+
 
 """
 def test_remove_inf_all_inf_values(singlereader):

--- a/ftag/tests/hdf5/test_h5utils.py
+++ b/ftag/tests/hdf5/test_h5utils.py
@@ -3,6 +3,7 @@ import pytest
 
 from ftag.hdf5.h5utils import cast_dtype, get_dtype, join_structured_arrays
 from ftag.mock import get_mock_file
+from ftag.transform import Transform
 
 
 def test_get_dtype():
@@ -21,6 +22,15 @@ def test_get_dtype():
     variables = ["pt", "eta"]
     expected_dtype = np.dtype([("pt", "f2"), ("eta", "f2")])
     assert get_dtype(ds, variables, "half") == expected_dtype
+
+
+def test_get_dtype_with_transform():
+    tf = Transform(variable_map={"jets": {"pt": "pt_new"}})
+    f = get_mock_file()[1]
+    ds = f["jets"]
+    variables = ["pt_new", "eta"]
+    expected_dtype = np.dtype([("pt", "f4"), ("eta", "f4")])
+    assert get_dtype(ds, variables, transform=tf) == expected_dtype
 
 
 def test_cast_dtype():

--- a/ftag/tests/test_transform.py
+++ b/ftag/tests/test_transform.py
@@ -20,7 +20,10 @@ def floats_map():
     return {
         "group3": {
             "var5": "log10",
-        }
+        },
+        "group99": {
+            "var5": "log10",
+        },
     }
 
 
@@ -32,6 +35,9 @@ def ints_map():
             "new_var2": {2: 20},
         },
         "group2": {
+            "var3": {5: 50},
+        },
+        "group99": {
             "var3": {5: 50},
         },
     }
@@ -102,7 +108,8 @@ def test_map_floats(sample_batch, floats_map):
 def test_map_dtype_existing_variables():
     name = "group1"
     fail_map = {name: {"var1": "var2"}}
-    your_class_instance = Transform(fail_map)
+    tf = Transform(fail_map)
     dtype = np.dtype([("var1", "int32"), ("var2", "float64")])
+    assert tf.map_dtype("test", dtype) == dtype
     with pytest.raises(ValueError):
-        your_class_instance.map_dtype(name, dtype)
+        tf.map_dtype(name, dtype)

--- a/ftag/tests/test_transform.py
+++ b/ftag/tests/test_transform.py
@@ -38,7 +38,7 @@ def ints_map():
 
 
 @pytest.fixture
-def variable_name_map():
+def variable_map():
     return {
         "group1": {
             "var1": "new_var1",
@@ -57,8 +57,8 @@ def test_map_ints(sample_batch, ints_map):
     assert transformed_batch["group2"]["var3"].tolist() == [50, 7]
 
 
-def test_map_variables(sample_batch, variable_name_map):
-    transform = Transform(variable_name_map)
+def test_map_variables(sample_batch, variable_map):
+    transform = Transform(variable_map)
     transformed_batch = transform.map_variables(sample_batch)
 
     assert "new_var1" in transformed_batch["group1"].dtype.names
@@ -72,18 +72,18 @@ def test_map_variables(sample_batch, variable_name_map):
 
 
 def test_map_variables_existing_variable(sample_batch):
-    variable_name_map = {
+    variable_map = {
         "group1": {
             "var1": "var2",
         },
     }
-    transform = Transform(variable_name_map)
+    transform = Transform(variable_map)
     with pytest.raises(ValueError):
         transform.map_variables(sample_batch)
 
 
-def test_transform_call(sample_batch, variable_name_map, ints_map):
-    transform = Transform(variable_name_map, ints_map)
+def test_transform_call(sample_batch, variable_map, ints_map):
+    transform = Transform(variable_map, ints_map)
     transformed_batch = transform(sample_batch)
 
     assert "new_var2" in transformed_batch["group1"].dtype.names
@@ -97,3 +97,12 @@ def test_map_floats(sample_batch, floats_map):
     transform = Transform(floats_map=floats_map)
     transformed_batch = transform.map_floats(sample_batch)
     assert transformed_batch["group3"]["var5"].tolist() == [1.0, 2.0]
+
+
+def test_map_dtype_existing_variables():
+    name = "group1"
+    fail_map = {name: {"var1": "var2"}}
+    your_class_instance = Transform(fail_map)
+    dtype = np.dtype([("var1", "int32"), ("var2", "float64")])
+    with pytest.raises(ValueError):
+        your_class_instance.map_dtype(name, dtype)

--- a/ftag/tests/test_transform.py
+++ b/ftag/tests/test_transform.py
@@ -1,0 +1,108 @@
+import numpy as np
+import pytest
+
+from ftag.transform import Transform
+
+
+@pytest.fixture
+def sample_batch():
+    return {
+        "group1": np.array([(1, 2), (3, 4)], dtype=[("var1", int), ("var2", int)]),
+        "group2": np.array([(5, 6), (7, 8)], dtype=[("var3", int), ("var4", int)]),
+    }
+
+
+def test_map_ints(sample_batch):
+    ints_map = {
+        "group1": {
+            "var1": {1: 10},
+            "var2": {2: 20},
+        },
+        "group2": {
+            "var3": {5: 50},
+            "var4": {6: 60},
+        },
+    }
+    transformer = Transform(ints_map=ints_map)
+    transformed_batch = transformer.map_ints(sample_batch)
+    assert transformed_batch["group1"]["var1"].tolist() == [10, 3]
+    assert transformed_batch["group1"]["var2"].tolist() == [20, 4]
+    assert transformed_batch["group2"]["var3"].tolist() == [50, 7]
+    assert transformed_batch["group2"]["var4"].tolist() == [60, 8]
+
+
+def test_rename_variables(sample_batch):
+    variable_name_map = {
+        "group1": {
+            "var1": "new_var1",
+            "var2": "new_var2",
+        },
+        "group2": {
+            "var3": "new_var3",
+        },
+    }
+    transformer = Transform(variable_name_map)
+    transformed_batch = transformer.rename_variables(sample_batch)
+
+    assert "new_var1" in transformed_batch["group1"].dtype.names
+    assert "new_var2" in transformed_batch["group1"].dtype.names
+    assert "new_var3" in transformed_batch["group2"].dtype.names
+    assert "var4" in transformed_batch["group2"].dtype.names
+    assert "var1" not in transformed_batch["group1"].dtype.names
+    assert "var2" not in transformed_batch["group1"].dtype.names
+    assert "var3" not in transformed_batch["group2"].dtype.names
+    assert "new_var4" not in transformed_batch["group2"].dtype.names
+
+
+def test_rename_variables_existing_variable(sample_batch):
+    variable_name_map = {
+        "group1": {
+            "var1": "var2",
+        },
+    }
+    transformer = Transform(variable_name_map)
+    with pytest.raises(ValueError):
+        transformer.rename_variables(sample_batch)
+
+
+def test_transform_call(sample_batch):
+    # Sample maps for testing
+    variable_name_map = {
+        "group1": {
+            "var1": "new_var1",
+            "var2": "new_var2",
+        },
+        "group2": {
+            "var3": "new_var3",
+            "var4": "new_var4",
+        },
+    }
+
+    ints_map = {
+        "group1": {
+            "new_var1": {1: 10},
+            "new_var2": {2: 20},
+        },
+        "group2": {
+            "new_var3": {5: 50},
+            "new_var4": {6: 60},
+        },
+    }
+
+    transformer = Transform(variable_name_map, ints_map)
+    transformed_batch = transformer(sample_batch)
+
+    # Verify that variables are renamed and integers are mapped
+    assert "new_var1" in transformed_batch["group1"].dtype.names
+    assert "new_var2" in transformed_batch["group1"].dtype.names
+    assert "new_var3" in transformed_batch["group2"].dtype.names
+    assert "new_var4" in transformed_batch["group2"].dtype.names
+    assert "var1" not in transformed_batch["group1"].dtype.names
+    assert "var2" not in transformed_batch["group1"].dtype.names
+    assert "var3" not in transformed_batch["group2"].dtype.names
+    assert "var4" not in transformed_batch["group2"].dtype.names
+
+    assert transformed_batch["group1"]["new_var1"].tolist() == [10, 3]
+    assert transformed_batch["group1"]["new_var2"].tolist() == [20, 4]
+    assert transformed_batch["group2"]["new_var3"].tolist() == [50, 7]
+    assert transformed_batch["group2"]["new_var4"].tolist() == [60, 8]

--- a/ftag/tests/test_transform.py
+++ b/ftag/tests/test_transform.py
@@ -32,7 +32,7 @@ def ints_map():
     return {
         "group1": {
             "var2": {2: 20},
-            "new_var2": {2: 20},
+            "new_var2": {2: 30},
         },
         "group2": {
             "var3": {5: 50},
@@ -96,7 +96,7 @@ def test_transform_call(sample_batch, variable_map, ints_map):
     assert "new_var3" in transformed_batch["group2"].dtype.names
     assert "var3" not in transformed_batch["group2"].dtype.names
     assert transformed_batch["group1"]["new_var2"].tolist() == [20, 4]
-    assert transformed_batch["group2"]["new_var3"].tolist() == [5, 7]
+    assert transformed_batch["group2"]["new_var3"].tolist() == [50, 7]
 
 
 def test_map_floats(sample_batch, floats_map):

--- a/ftag/tests/test_transform.py
+++ b/ftag/tests/test_transform.py
@@ -57,9 +57,9 @@ def test_map_ints(sample_batch, ints_map):
     assert transformed_batch["group2"]["var3"].tolist() == [50, 7]
 
 
-def test_rename_variables(sample_batch, variable_name_map):
+def test_map_variables(sample_batch, variable_name_map):
     transform = Transform(variable_name_map)
-    transformed_batch = transform.rename_variables(sample_batch)
+    transformed_batch = transform.map_variables(sample_batch)
 
     assert "new_var1" in transformed_batch["group1"].dtype.names
     assert "new_var2" in transformed_batch["group1"].dtype.names
@@ -71,7 +71,7 @@ def test_rename_variables(sample_batch, variable_name_map):
     assert "new_var4" not in transformed_batch["group2"].dtype.names
 
 
-def test_rename_variables_existing_variable(sample_batch):
+def test_map_variables_existing_variable(sample_batch):
     variable_name_map = {
         "group1": {
             "var1": "var2",
@@ -79,7 +79,7 @@ def test_rename_variables_existing_variable(sample_batch):
     }
     transform = Transform(variable_name_map)
     with pytest.raises(ValueError):
-        transform.rename_variables(sample_batch)
+        transform.map_variables(sample_batch)
 
 
 def test_transform_call(sample_batch, variable_name_map, ints_map):
@@ -93,7 +93,7 @@ def test_transform_call(sample_batch, variable_name_map, ints_map):
     assert transformed_batch["group2"]["new_var3"].tolist() == [5, 7]
 
 
-def test_transform_floats(sample_batch, floats_map):
+def test_map_floats(sample_batch, floats_map):
     transform = Transform(floats_map=floats_map)
-    transformed_batch = transform.transform_floats(sample_batch)
+    transformed_batch = transform.map_floats(sample_batch)
     assert transformed_batch["group3"]["var5"].tolist() == [1.0, 2.0]

--- a/ftag/tests/test_transform.py
+++ b/ftag/tests/test_transform.py
@@ -9,30 +9,37 @@ def sample_batch():
     return {
         "group1": np.array([(1, 2), (3, 4)], dtype=[("var1", int), ("var2", int)]),
         "group2": np.array([(5, 6), (7, 8)], dtype=[("var3", int), ("var4", int)]),
+        "group3": np.array(
+            [(10.0, 100.0), (100.0, 10.0)], dtype=[("var5", float), ("var6", float)]
+        ),
     }
 
 
-def test_map_ints(sample_batch):
-    ints_map = {
+@pytest.fixture
+def floats_map():
+    return {
+        "group3": {
+            "var5": "log10",
+        }
+    }
+
+
+@pytest.fixture
+def ints_map():
+    return {
         "group1": {
-            "var1": {1: 10},
             "var2": {2: 20},
+            "new_var2": {2: 20},
         },
         "group2": {
             "var3": {5: 50},
-            "var4": {6: 60},
         },
     }
-    transformer = Transform(ints_map=ints_map)
-    transformed_batch = transformer.map_ints(sample_batch)
-    assert transformed_batch["group1"]["var1"].tolist() == [10, 3]
-    assert transformed_batch["group1"]["var2"].tolist() == [20, 4]
-    assert transformed_batch["group2"]["var3"].tolist() == [50, 7]
-    assert transformed_batch["group2"]["var4"].tolist() == [60, 8]
 
 
-def test_rename_variables(sample_batch):
-    variable_name_map = {
+@pytest.fixture
+def variable_name_map():
+    return {
         "group1": {
             "var1": "new_var1",
             "var2": "new_var2",
@@ -41,8 +48,18 @@ def test_rename_variables(sample_batch):
             "var3": "new_var3",
         },
     }
-    transformer = Transform(variable_name_map)
-    transformed_batch = transformer.rename_variables(sample_batch)
+
+
+def test_map_ints(sample_batch, ints_map):
+    transform = Transform(ints_map=ints_map)
+    transformed_batch = transform.map_ints(sample_batch)
+    assert transformed_batch["group1"]["var2"].tolist() == [20, 4]
+    assert transformed_batch["group2"]["var3"].tolist() == [50, 7]
+
+
+def test_rename_variables(sample_batch, variable_name_map):
+    transform = Transform(variable_name_map)
+    transformed_batch = transform.rename_variables(sample_batch)
 
     assert "new_var1" in transformed_batch["group1"].dtype.names
     assert "new_var2" in transformed_batch["group1"].dtype.names
@@ -60,49 +77,23 @@ def test_rename_variables_existing_variable(sample_batch):
             "var1": "var2",
         },
     }
-    transformer = Transform(variable_name_map)
+    transform = Transform(variable_name_map)
     with pytest.raises(ValueError):
-        transformer.rename_variables(sample_batch)
+        transform.rename_variables(sample_batch)
 
 
-def test_transform_call(sample_batch):
-    # Sample maps for testing
-    variable_name_map = {
-        "group1": {
-            "var1": "new_var1",
-            "var2": "new_var2",
-        },
-        "group2": {
-            "var3": "new_var3",
-            "var4": "new_var4",
-        },
-    }
+def test_transform_call(sample_batch, variable_name_map, ints_map):
+    transform = Transform(variable_name_map, ints_map)
+    transformed_batch = transform(sample_batch)
 
-    ints_map = {
-        "group1": {
-            "new_var1": {1: 10},
-            "new_var2": {2: 20},
-        },
-        "group2": {
-            "new_var3": {5: 50},
-            "new_var4": {6: 60},
-        },
-    }
-
-    transformer = Transform(variable_name_map, ints_map)
-    transformed_batch = transformer(sample_batch)
-
-    # Verify that variables are renamed and integers are mapped
-    assert "new_var1" in transformed_batch["group1"].dtype.names
     assert "new_var2" in transformed_batch["group1"].dtype.names
     assert "new_var3" in transformed_batch["group2"].dtype.names
-    assert "new_var4" in transformed_batch["group2"].dtype.names
-    assert "var1" not in transformed_batch["group1"].dtype.names
-    assert "var2" not in transformed_batch["group1"].dtype.names
     assert "var3" not in transformed_batch["group2"].dtype.names
-    assert "var4" not in transformed_batch["group2"].dtype.names
-
-    assert transformed_batch["group1"]["new_var1"].tolist() == [10, 3]
     assert transformed_batch["group1"]["new_var2"].tolist() == [20, 4]
-    assert transformed_batch["group2"]["new_var3"].tolist() == [50, 7]
-    assert transformed_batch["group2"]["new_var4"].tolist() == [60, 8]
+    assert transformed_batch["group2"]["new_var3"].tolist() == [5, 7]
+
+
+def test_transform_floats(sample_batch, floats_map):
+    transform = Transform(floats_map=floats_map)
+    transformed_batch = transform.transform_floats(sample_batch)
+    assert transformed_batch["group3"]["var5"].tolist() == [1.0, 2.0]

--- a/ftag/transform.py
+++ b/ftag/transform.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable
 

--- a/ftag/transform.py
+++ b/ftag/transform.py
@@ -28,7 +28,9 @@ class Transform:
                 self.floats_map[group][variable] = getattr(np, func)
 
     def __call__(self, batch: Batch) -> Batch:
-        return self.map_floats(self.map_ints(self.map_variables(batch)))
+        batch = self.map_ints(batch)
+        batch = self.map_floats(batch)
+        return self.map_variables(batch)
 
     def map_variables(self, batch: Batch) -> Batch:
         """

--- a/ftag/transform.py
+++ b/ftag/transform.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+
+__all__ = ["Transform"]
+
+
+@dataclass
+class Transform:
+    variable_name_map: dict[str, dict[str, str]] | None = None
+    ints_map: dict[str, dict[str, dict[int, int]]] | None = None
+
+    def __post_init__(self):
+        if self.variable_name_map is None:
+            self.variable_name_map = {}
+        if self.ints_map is None:
+            self.ints_map = {}
+
+    def __call__(self, batch: dict) -> dict:
+        return self.map_ints(self.rename_variables(batch))
+
+    def rename_variables(self, batch: dict) -> dict:
+        """
+        Rename variables in a batch of data.
+
+        Parameters
+        ----------
+        batch : dict
+            Dict of structured numpy arrays.
+
+        Returns
+        -------
+        dict
+            Dict of structured numpy arrays with renamed variables.
+        """
+        assert self.variable_name_map is not None
+        for group, remap in self.variable_name_map.items():
+            dtype = batch[group].dtype
+            names = list(dtype.names)
+            for old, new in remap.items():
+                if new in names:
+                    raise ValueError(f"Variable {new} already exists in {group}.")
+                if old in names:
+                    names[names.index(old)] = new
+            dtype.names = names
+
+        return batch
+
+    def map_ints(self, batch: dict) -> dict:
+        """
+        Map integer values to new values.
+
+        Parameters
+        ----------
+        batch : dict
+            Dict of structured numpy arrays.
+
+        Returns
+        -------
+        dict
+            Dict of structured numpy arrays with mapped integer values.
+        """
+        assert self.ints_map is not None
+        for group, map_dict in self.ints_map.items():
+            for variable, int_map in map_dict.items():
+                data = batch[group][variable]
+                for old, new in int_map.items():
+                    data[data == old] = new
+        return batch

--- a/ftag/transform.py
+++ b/ftag/transform.py
@@ -1,4 +1,7 @@
 from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
 
 __all__ = ["Transform"]
 
@@ -7,12 +10,20 @@ __all__ = ["Transform"]
 class Transform:
     variable_name_map: dict[str, dict[str, str]] | None = None
     ints_map: dict[str, dict[str, dict[int, int]]] | None = None
+    floats_map: dict[str, dict[str, str | Callable]] | None = None
 
     def __post_init__(self):
         if self.variable_name_map is None:
             self.variable_name_map = {}
         if self.ints_map is None:
             self.ints_map = {}
+        if self.floats_map is None:
+            self.floats_map = {}
+
+        # convert string to callable
+        for group, map_dict in self.floats_map.items():
+            for variable, func in map_dict.items():
+                self.floats_map[group][variable] = getattr(np, func)
 
     def __call__(self, batch: dict) -> dict:
         return self.map_ints(self.rename_variables(batch))
@@ -61,7 +72,30 @@ class Transform:
         assert self.ints_map is not None
         for group, map_dict in self.ints_map.items():
             for variable, int_map in map_dict.items():
+                if variable not in batch[group].dtype.names:
+                    continue
                 data = batch[group][variable]
                 for old, new in int_map.items():
                     data[data == old] = new
+        return batch
+
+    def transform_floats(self, batch: dict) -> dict:
+        """
+        Transform float values.
+
+        Parameters
+        ----------
+        batch : dict
+            Dict of structured numpy arrays.
+
+        Returns
+        -------
+        dict
+            Dict of structured numpy arrays with transformed float values.
+        """
+        assert self.floats_map is not None
+        for group, map_dict in self.floats_map.items():
+            for variable, func in map_dict.items():
+                assert callable(func)
+                batch[group][variable] = func(batch[group][variable])
         return batch

--- a/ftag/transform.py
+++ b/ftag/transform.py
@@ -5,6 +5,8 @@ import numpy as np
 
 __all__ = ["Transform"]
 
+Batch = dict[str, np.ndarray]
+
 
 @dataclass
 class Transform:
@@ -25,52 +27,77 @@ class Transform:
             for variable, func in map_dict.items():
                 self.floats_map[group][variable] = getattr(np, func)
 
-    def __call__(self, batch: dict) -> dict:
-        return self.map_ints(self.rename_variables(batch))
+    def __call__(self, batch: Batch) -> Batch:
+        return self.map_floats(self.map_ints(self.map_variables(batch)))
 
-    def rename_variables(self, batch: dict) -> dict:
+    def map_dtype(self, name: str, dtype: np.dtype, inverse=False) -> np.dtype:
+        """
+        Rename variables in a dtype.
+
+        Parameters
+        ----------
+        name : str
+            Name of the group.
+        dtype : np.dtype
+            Structured numpy array dtype.
+        inverse : bool, optional
+            If True, apply the inverse mapping, by default False.
+
+        Returns
+        -------
+        np.dtype
+            A new dtype with renamed variables.
+        """
+        assert self.variable_name_map is not None
+        names = list(dtype.names)
+        remap = self.variable_name_map.get(name)
+        if not remap:
+            return dtype
+        for old, new in remap.items():
+            if old in names and new in names:
+                raise ValueError(f"Variables {old, new} already exists in {name}.")
+        if inverse:
+            remap = {v: k for k, v in remap.items()}
+        return np.dtype([(remap.get(name, name), dtype[name]) for name in names])
+
+    def map_variables(self, batch: Batch) -> Batch:
         """
         Rename variables in a batch of data.
 
         Parameters
         ----------
-        batch : dict
+        batch : Batch
             Dict of structured numpy arrays.
 
         Returns
         -------
-        dict
+        Batch
             Dict of structured numpy arrays with renamed variables.
         """
         assert self.variable_name_map is not None
-        for group, remap in self.variable_name_map.items():
-            dtype = batch[group].dtype
-            names = list(dtype.names)
-            for old, new in remap.items():
-                if new in names:
-                    raise ValueError(f"Variable {new} already exists in {group}.")
-                if old in names:
-                    names[names.index(old)] = new
-            dtype.names = names
-
+        for group in self.variable_name_map:
+            if group in batch:
+                batch[group] = batch[group].astype(self.map_dtype(group, batch[group].dtype))
         return batch
 
-    def map_ints(self, batch: dict) -> dict:
+    def map_ints(self, batch: Batch) -> Batch:
         """
         Map integer values to new values.
 
         Parameters
         ----------
-        batch : dict
+        batch : Batch
             Dict of structured numpy arrays.
 
         Returns
         -------
-        dict
+        Batch
             Dict of structured numpy arrays with mapped integer values.
         """
         assert self.ints_map is not None
         for group, map_dict in self.ints_map.items():
+            if group not in batch:
+                continue
             for variable, int_map in map_dict.items():
                 if variable not in batch[group].dtype.names:
                     continue
@@ -79,22 +106,24 @@ class Transform:
                     data[data == old] = new
         return batch
 
-    def transform_floats(self, batch: dict) -> dict:
+    def map_floats(self, batch: Batch) -> Batch:
         """
         Transform float values.
 
         Parameters
         ----------
-        batch : dict
+        batch : Batch
             Dict of structured numpy arrays.
 
         Returns
         -------
-        dict
+        Batch
             Dict of structured numpy arrays with transformed float values.
         """
         assert self.floats_map is not None
         for group, map_dict in self.floats_map.items():
+            if group not in batch:
+                continue
             for variable, func in map_dict.items():
                 assert callable(func)
                 batch[group][variable] = func(batch[group][variable])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
 [project.scripts]
 vds = "ftag.vds:main"
 wps = "ftag.wps.working_points:main"
+h5move = "ftag.hdf5.h5move:main"
 
 [tool.setuptools]
 packages = ["ftag", "ftag.hdf5", "ftag.wps"]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add `Transform` class which can apply on the fly transformations to loaded data
* Transformations include: variable renaming, int remapping, and numpy transformations
* Revert unfreeze `Flavour` class from #43 as it breaks UPP
* Add `h5move` command which can rename datasets in a file

Relates to the following issues

* https://github.com/umami-hep/umami-preprocessing/issues/3

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
