### PR TITLE
Add h5split

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,6 @@ Running `coverage report` will display the test coverage.
 Please see the [example notebook](ftag/example.ipynb) for full usage.
 Additional functionality is also documented below.
 
-## Create virtual file
-
-This package contains a script to easily merge a set of H5 files.
-A virtual file is a fast and lightweight way to wrap a set of files.
-See the [h5py documentation](https://docs.h5py.org/en/stable/vds.html) for more information on virtual datasets.
-
-The script is `vds.py` and can be run after installing this package with
-
-```
-vds <pattern> <output path>
-```
-
-The `<pattern>` argument should be a quotes enclosed [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)), for example `"dsid/path/*.h5"`
-
-See `vds --help` for more options and information.
-
-
 ## Calculate WPs
 
 This package contains a script to calculate tagger working points (WPs).
@@ -99,3 +82,34 @@ By default the working points are printed to the terminal, but you can save the 
 See `wps --help` for more options and information.
 
 
+## H5 Utils
+
+### Create virtual file
+
+This package contains a script to easily merge a set of H5 files.
+A virtual file is a fast and lightweight way to wrap a set of files.
+See the [h5py documentation](https://docs.h5py.org/en/stable/vds.html) for more information on virtual datasets.
+
+The script is `vds.py` and can be run after installing this package with
+
+```
+vds <pattern> <output path>
+```
+
+The `<pattern>` argument should be a quotes enclosed [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)), for example `"dsid/path/*.h5"`
+
+See `vds --help` for more options and information.
+
+
+### [h5move](ftag/hdf5/h5move.py)
+
+A script to move/rename datasets inside an h5file.
+Useful for correcting discrepancies between group names.
+See [h5move.py](ftag/hdf5/h5move.py) for more info.
+
+
+### [h5split](ftag/hdf5/h5split.py)
+
+A script to split a large h5 file into several smaller files.
+Useful if output files are too large for EOS/grid storage.
+See [h5split.py](ftag/hdf5/h5split.py) for more info.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Add h5split command [#47](https://github.com/umami-hep/atlas-ftag-tools/pull/47)
 
 ### [v0.1.7]
 - Improvements to the H5Writer interface [#46](https://github.com/umami-hep/atlas-ftag-tools/pull/46)

--- a/ftag/hdf5/h5move.py
+++ b/ftag/hdf5/h5move.py
@@ -1,3 +1,5 @@
+"""A script to move (i.e. rename) a dataset in an h5 file."""
+
 from __future__ import annotations
 
 import argparse
@@ -7,13 +9,19 @@ import h5py
 
 
 def parse_args(args):
-    parser = argparse.ArgumentParser(description="Move/rename a dataset in an h5 file")
-    parser.add_argument("fname", type=Path, help="path to h5 file")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fname", required=True, type=Path, help="path to h5 file")
     parser.add_argument(
-        "src", type=str, help="path within h5 file to source dataset, starts with '/'"
+        "--src",
+        required=True,
+        type=str,
+        help="path within h5 file to source dataset, starts with '/'",
     )
     parser.add_argument(
-        "dst", type=str, help="path within h5 file to destination dataset, starts with '/'"
+        "--dst",
+        required=True,
+        type=str,
+        help="path within h5 file to destination dataset, starts with '/'",
     )
     return parser.parse_args(args)
 

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -72,8 +72,8 @@ class H5SingleReader:
         self,
         variables: dict | None = None,
         num_jets: int | None = None,
-        start: int = 0,
         cuts: Cuts | None = None,
+        start: int = 0,
     ) -> Generator:
         if num_jets is None:
             num_jets = self.num_jets
@@ -233,8 +233,8 @@ class H5Reader:
         self,
         variables: dict | None = None,
         num_jets: int | None = None,
-        start: int = 0,
         cuts: Cuts | None = None,
+        start: int = 0,
     ) -> Generator:
         """Generate batches of selected jets.
 
@@ -244,10 +244,10 @@ class H5Reader:
             Dictionary of variables to for each group, by default use all jet variables.
         num_jets : int | None, optional
             Total number of selected jets to generate, by default all.
-        start : int, optional
-            Starting index of the first jet to read, by default 0
         cuts : Cuts | None, optional
             Selection cuts to apply, by default None
+        start : int, optional
+            Starting index of the first jet to read, by default 0
 
         Yields
         ------
@@ -268,7 +268,7 @@ class H5Reader:
 
         # get streams for selected jets from each reader
         streams = [
-            r.stream(variables, int(r.num_jets / self.num_jets * num_jets), start, cuts)
+            r.stream(variables, int(r.num_jets / self.num_jets * num_jets), cuts, start)
             for r in self.readers
         ]
 
@@ -331,7 +331,7 @@ class H5Reader:
 
         # get data from each sample
         data: dict[str, list] = {name: [] for name in variables}
-        for batch in self.stream(variables, num_jets, cuts=cuts):
+        for batch in self.stream(variables, num_jets, cuts):
             for name, array in batch.items():
                 if name in data:
                     data[name].append(array)

--- a/ftag/hdf5/h5split.py
+++ b/ftag/hdf5/h5split.py
@@ -1,0 +1,75 @@
+"""A script to split a large h5 file into smaller h5 files along the first index."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import h5py
+
+from ftag.hdf5 import H5Reader, H5Writer
+
+
+class HelpFormatter(argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter):
+    ...
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=HelpFormatter)
+    parser.add_argument("--src", required=True, type=Path, help="path to source h5 file")
+    parser.add_argument(
+        "--dst",
+        type=Path,
+        help=(
+            "output directory contaning split files. by default use a new directory in the same"
+            " directory as the source file"
+        ),
+    )
+    parser.add_argument(
+        "-n", "--jets_per_file", type=int, default=1_000_000, help="number of jets per output file"
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_size",
+        type=int,
+        default=100_000,
+        help="number of jets to read/write at a time",
+    )
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    args = parse_args(args)
+
+    src = args.src
+    if args.dst is None:
+        dst = src.parent / f"split_{src.stem}"
+    jets_per_file = args.jets_per_file
+
+    print(f"\nSplitting: {src}")
+    print(f"Destination: {dst}")
+    with h5py.File(src, "r") as f:
+        total_jets = list(f.values())[0].shape[0]
+
+    num_output_files = total_jets // jets_per_file
+    remainder = total_jets % jets_per_file
+    num_output_files += 1 if remainder != 0 else 0
+    print(f"\n{total_jets:,} jets will be split across {num_output_files:,} files\n")
+
+    reader = H5Reader(src, batch_size=args.batch_size, shuffle=False)
+    variables = dict.fromkeys(reader.dtypes().keys())
+    for i in range(num_output_files):
+        start = i * jets_per_file
+        out = dst / f"{src.stem}-split_{i}.h5"
+        writer = H5Writer.from_file(src, dst=out, num_jets=jets_per_file, shuffle=False)
+        for batch in reader.stream(variables=variables, num_jets=jets_per_file, start=start):
+            writer.write(batch)
+            total_written = start + writer.num_written
+            pct_done = total_written / total_jets
+            print(f"\rProcessed {total_written:,}/{total_jets:,} jets ({pct_done:.1%})", end="")
+        writer.close()
+
+    print("\nDone!\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -70,7 +70,9 @@ def get_mock_scores(labels: np.ndarray):
     return u2s(scores, dtype=np.dtype([(name, "f4") for name in cols]))
 
 
-def get_mock_file(num_jets=1000, tracks_name: str = "tracks", num_tracks: int = 40):
+def get_mock_file(
+    num_jets=1000, tracks_name: str = "tracks", num_tracks: int = 40
+) -> tuple[str, h5py.File]:
     # setup jets
     rng = np.random.default_rng(42)
     jets_dtype = np.dtype(JET_VARS)

--- a/ftag/tests/hdf5/test_h5move.py
+++ b/ftag/tests/hdf5/test_h5move.py
@@ -14,7 +14,14 @@ def get_fname():
 
 def test_parse_args():
     # Test for the parse_args function
-    args = ["/path/to/file.h5", "/source/dataset", "/destination/dataset"]
+    args = [
+        "--fname",
+        "/path/to/file.h5",
+        "--src",
+        "/source/dataset",
+        "--dst",
+        "/destination/dataset",
+    ]
     parsed_args = parse_args(args)
     assert parsed_args.fname == Path("/path/to/file.h5")
     assert parsed_args.src == "/source/dataset"
@@ -25,7 +32,7 @@ def test_main(get_fname):
     fname = get_fname
     old_data = h5py.File(fname)["/jets"][:]
 
-    main([fname, "/jets", "/jets_new"])
+    main(["--fname", fname, "--src", "/jets", "--dst", "/jets_new"])
 
     f = h5py.File(fname)
     assert "/jets" not in f

--- a/ftag/tests/hdf5/test_h5split.py
+++ b/ftag/tests/hdf5/test_h5split.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import h5py
+import pytest
+
+from ftag import get_mock_file
+from ftag.hdf5.h5split import main, parse_args
+
+
+# Define a fixture to provide mock data
+@pytest.fixture
+def mock_h5_file():
+    file_path = get_mock_file()[0]
+    return Path(file_path)
+
+
+def test_parse_args():
+    args = ["--src", "input.h5", "--jets_per_file", "1000"]
+    parsed_args = parse_args(args)
+    assert parsed_args.src == Path("input.h5")
+    assert parsed_args.jets_per_file == 1000
+
+
+def test_main(mock_h5_file, capsys):
+    args = ["--src", str(mock_h5_file), "--jets_per_file", "100", "--batch_size", "10"]
+    main(args)
+
+    captured = capsys.readouterr()
+
+    assert "Done!" in captured.out
+    assert captured.err == ""
+    split_dir = mock_h5_file.parent / f"split_{mock_h5_file.stem}"
+    assert split_dir.exists()
+    num_output_files = len(list(split_dir.glob("*.h5")))
+    assert num_output_files == 10
+
+    # check file content
+    for i, f in enumerate(sorted(split_dir.glob("*.h5"))):
+        start = i * 100
+        stop = start + 100
+        with h5py.File(f) as dst, h5py.File(mock_h5_file) as src:
+            assert src.keys() == dst.keys()
+            for k in src:
+                assert (src[k][start:stop] == dst[k]).all()

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pytest
 
@@ -13,6 +14,12 @@ def mock_data():
     jets = f["jets"][:100][["pt", "eta"]]
     tracks = f["tracks"][:100]
     return jets, tracks
+
+
+@pytest.fixture
+def mock_data_path():
+    f = get_mock_file()[1]
+    return f.filename
 
 
 @pytest.fixture
@@ -86,3 +93,16 @@ def test_invalid_write(tmp_path, jet_dtype):
     data = {"jets": np.zeros(110, dtype=writer.dtypes["jets"])}
     with pytest.raises(ValueError):
         writer.write(data)
+
+
+def test_from_file(tmp_path, mock_data_path):
+    f = get_mock_file()[1]
+    jets = f["jets"][:]
+    tracks = f["tracks"][:]
+
+    dst_path = Path(tmp_path) / "test.h5"
+    writer = H5Writer.from_file(source=mock_data_path, dst=dst_path)
+
+    writer.write({"jets": jets, "tracks": tracks})
+    with h5py.File(dst_path) as f:
+        assert np.array_equal(f["jets"][:], jets)

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -101,7 +101,7 @@ def test_from_file(tmp_path, mock_data_path):
     tracks = f["tracks"][:]
 
     dst_path = Path(tmp_path) / "test.h5"
-    writer = H5Writer.from_file(source=mock_data_path, dst=dst_path)
+    writer = H5Writer.from_file(source=mock_data_path, dst=dst_path, shuffle=False)
 
     writer.write({"jets": jets, "tracks": tracks})
     with h5py.File(dst_path) as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
 vds = "ftag.vds:main"
 wps = "ftag.wps.working_points:main"
 h5move = "ftag.hdf5.h5move:main"
+h5split = "ftag.hdf5.h5split:main"
 
 [tool.setuptools]
 packages = ["ftag", "ftag.hdf5", "ftag.wps"]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add a function to split a large h5 into several smaller h5

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
