### PR TITLE
backward compatibility to python3.8 and small fix for h5split.py

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Backward compatibility to python3.8 and small fix for h5split.py [#48](https://github.com/umami-hep/atlas-ftag-tools/pull/48)
 - Add h5split command [#47](https://github.com/umami-hep/atlas-ftag-tools/pull/47)
 
 ### [v0.1.7]

--- a/ftag/hdf5/h5split.py
+++ b/ftag/hdf5/h5split.py
@@ -41,7 +41,8 @@ def main(args=None):
     args = parse_args(args)
 
     src = args.src
-    if args.dst is None:
+    dst = args.dst
+    if dst is None:
         dst = src.parent / f"split_{src.stem}"
     jets_per_file = args.jets_per_file
 

--- a/ftag/transform.py
+++ b/ftag/transform.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, Dict
 
 import numpy as np
 
 __all__ = ["Transform"]
 
-Batch = dict[str, np.ndarray]
+Batch = Dict[str, np.ndarray]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* using `typing` module to ensure code runs with python 3.8
* small fix in `h5split.py`

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
