### PR TITLE
Fixed bug where h5split didn't work with remainders

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### [Latest]
 
 ### [v0.1.8]
+- Fix to h5split to allow files with remainders [#49](https://github.com/umami-hep/atlas-ftag-tools/pull/49)
 - Backward compatibility to python3.8 and small fix for h5split.py [#48](https://github.com/umami-hep/atlas-ftag-tools/pull/48)
 - Add h5split command [#47](https://github.com/umami-hep/atlas-ftag-tools/pull/47)
 

--- a/ftag/hdf5/h5split.py
+++ b/ftag/hdf5/h5split.py
@@ -71,7 +71,7 @@ def main(args=None):
 
     if remainder != 0:
         start = num_full_files * jets_per_file
-        
+
         out = dst / f"{src.stem}-split_{num_total_files}.h5"
         writer = H5Writer.from_file(src, dst=out, num_jets=remainder, shuffle=False)
         for batch in reader.stream(variables=variables, num_jets=remainder, start=start):

--- a/ftag/hdf5/h5split.py
+++ b/ftag/hdf5/h5split.py
@@ -51,14 +51,14 @@ def main(args=None):
     with h5py.File(src, "r") as f:
         total_jets = list(f.values())[0].shape[0]
 
-    num_output_files = total_jets // jets_per_file
+    num_full_files = total_jets // jets_per_file
     remainder = total_jets % jets_per_file
-    num_output_files += 1 if remainder != 0 else 0
-    print(f"\n{total_jets:,} jets will be split across {num_output_files:,} files\n")
+    num_total_files = num_full_files + (1 if remainder != 0 else 0)
+    print(f"\n{total_jets:,} jets will be split across {num_total_files:,} files\n")
 
     reader = H5Reader(src, batch_size=args.batch_size, shuffle=False)
     variables = dict.fromkeys(reader.dtypes().keys())
-    for i in range(num_output_files):
+    for i in range(num_full_files):
         start = i * jets_per_file
         out = dst / f"{src.stem}-split_{i}.h5"
         writer = H5Writer.from_file(src, dst=out, num_jets=jets_per_file, shuffle=False)
@@ -69,6 +69,17 @@ def main(args=None):
             print(f"\rProcessed {total_written:,}/{total_jets:,} jets ({pct_done:.1%})", end="")
         writer.close()
 
+    if remainder != 0:
+        start = num_full_files * jets_per_file
+        
+        out = dst / f"{src.stem}-split_{num_total_files}.h5"
+        writer = H5Writer.from_file(src, dst=out, num_jets=remainder, shuffle=False)
+        for batch in reader.stream(variables=variables, num_jets=remainder, start=start):
+            writer.write(batch)
+            total_written = start + writer.num_written
+            pct_done = total_written / total_jets
+            print(f"\rProcessed {total_written:,}/{total_jets:,} jets ({pct_done:.1%})", end="")
+        writer.close()
     print("\nDone!\n")
 
 

--- a/ftag/tests/hdf5/test_h5split.py
+++ b/ftag/tests/hdf5/test_h5split.py
@@ -43,10 +43,11 @@ def test_main(mock_h5_file, capsys):
             for k in src:
                 assert (src[k][start:stop] == dst[k]).all()
 
+
 def test_remainder(mock_h5_file, capsys):
     args = ["--src", str(mock_h5_file), "--jets_per_file", "201", "--batch_size", "10"]
     main(args)
-    
+
     captured = capsys.readouterr()
     assert "Done!" in captured.out
     assert captured.err == ""

--- a/ftag/tests/hdf5/test_h5split.py
+++ b/ftag/tests/hdf5/test_h5split.py
@@ -42,3 +42,24 @@ def test_main(mock_h5_file, capsys):
             assert src.keys() == dst.keys()
             for k in src:
                 assert (src[k][start:stop] == dst[k]).all()
+
+def test_remainder(mock_h5_file, capsys):
+    args = ["--src", str(mock_h5_file), "--jets_per_file", "201", "--batch_size", "10"]
+    main(args)
+    
+    captured = capsys.readouterr()
+    assert "Done!" in captured.out
+    assert captured.err == ""
+    split_dir = mock_h5_file.parent / f"split_{mock_h5_file.stem}"
+    assert split_dir.exists()
+    num_output_files = len(list(split_dir.glob("*.h5")))
+    assert num_output_files == 5
+
+    # check file content
+    for i, f in enumerate(sorted(split_dir.glob("*.h5"))):
+        start = i * 201
+        stop = start + 201 if i <= 3 else 1000
+        with h5py.File(f) as dst, h5py.File(mock_h5_file) as src:
+            assert src.keys() == dst.keys()
+            for k in src:
+                assert (src[k][start:stop] == dst[k]).all()


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fixes 'h5split' to allow it to work when the number of jets per file isn't a factor of the total number of jets
* Add test function for h5split in the case when there should be a remainder. 

Relates to the following issues

*
*

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
