### PR TITLE
Fix new function imports

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Bugfix of `structured_from_dict` function [#53](https://github.com/umami-hep/atlas-ftag-tools/pull/54)
+
 ### [v0.1.10]
 - Add func to create structured array from dict of arrays [#52](https://github.com/umami-hep/atlas-ftag-tools/pull/52)
 - Copy attrs when splitting files [#51](https://github.com/umami-hep/atlas-ftag-tools/pull/51)

--- a/ftag/hdf5/__init__.py
+++ b/ftag/hdf5/__init__.py
@@ -10,5 +10,5 @@ __all__ = [
     "get_dtype",
     "cast_dtype",
     "join_structured_arrays",
-    "structured_from_dict"
+    "structured_from_dict",
 ]

--- a/ftag/hdf5/__init__.py
+++ b/ftag/hdf5/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ftag.hdf5.h5reader import H5Reader
-from ftag.hdf5.h5utils import cast_dtype, get_dtype, join_structured_arrays
+from ftag.hdf5.h5utils import cast_dtype, get_dtype, join_structured_arrays, structured_from_dict
 from ftag.hdf5.h5writer import H5Writer
 
 __all__ = [
@@ -10,5 +10,5 @@ __all__ = [
     "get_dtype",
     "cast_dtype",
     "join_structured_arrays",
-    "structured_from_dictget_mock_file",
+    "structured_from_dict"
 ]


### PR DESCRIPTION
## Summary

Fix the non-accessibility of the `structured_from_dict` function. 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
