### PR TITLE
Added 'not equal' cut for mod values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### [Latest]
 
 ### [v0.1.12]
+- Added 'X % M != n' cut [#61](https://github.com/umami-hep/atlas-ftag-tools/pull/61)
 - Update top labelling names [#39](https://github.com/umami-hep/atlas-ftag-tools/pull/39)
 - Add isolation classes [#58](https://github.com/umami-hep/atlas-ftag-tools/pull/58)
 

--- a/ftag/cuts.py
+++ b/ftag/cuts.py
@@ -22,6 +22,7 @@ OPERATORS = {
 
 for i in range(2, 101):
     OPERATORS[f"%{i}=="] = functools.partial(lambda x, y, i: (x % i) == y, i=i)
+    OPERATORS[f"%{i}!="] = functools.partial(lambda x, y, i: (x % i) != y, i=i)
     OPERATORS[f"%{i}<="] = functools.partial(lambda x, y, i: (x % i) <= y, i=i)
     OPERATORS[f"%{i}>="] = functools.partial(lambda x, y, i: (x % i) >= y, i=i)
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Introduces a 'X%n!=m' cut, for use in splitting dataset more finely.

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
