### PR TITLE
Only create virtual file with common groups

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Merge only common groups in virtual datasets [#63](https://github.com/umami-hep/atlas-ftag-tools/pull/63)
 
 ### [v0.1.13]
 - Add common git check functions  [#62](https://github.com/umami-hep/atlas-ftag-tools/pull/62)

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -48,6 +48,29 @@ def test_create_virtual_file(test_h5_files):
             assert len(f["data"]) == 25
 
 
+def test_create_virtual_file_common_groups(test_h5_files):
+    # create additional h5 files with different group
+    with tempfile.TemporaryDirectory() as tmpdir:
+        extra_files = []
+        for i in range(2):
+            filename = os.path.join(tmpdir, f"extra_file_{i}.h5")
+            with h5py.File(filename, "w") as f:
+                f.create_dataset("extra_data", data=[i] * 5)
+            extra_files.append(filename)
+
+        all_files = test_h5_files + extra_files
+        pattern = os.path.join(os.path.dirname(all_files[0]), "*.h5")
+
+        # create temporary output file
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            output_path = Path(tmpfile.name)
+            create_virtual_file(pattern, output_path, overwrite=True)
+
+            # check the output file
+            with h5py.File(output_path) as f:
+                assert "data" in f
+                assert "extra_data" not in f
+
 def test_main():
     # Create temporary directory to store test files
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -71,6 +71,7 @@ def test_create_virtual_file_common_groups(test_h5_files):
                 assert "data" in f
                 assert "extra_data" not in f
 
+
 def test_main():
     # Create temporary directory to store test files
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -67,7 +67,9 @@ def create_virtual_file(
     for fname in fnames:
         with h5py.File(fname) as f:
             groups = set(f.keys())
-            common_groups = groups if common_groups is None else common_groups.intersection(groups)
+            common_groups = (
+                groups if common_groups is None else common_groups.intersection(groups)
+            )  # type: ignore
 
     if not common_groups:
         raise ValueError("No common groups found across files")

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -63,13 +63,11 @@ def create_virtual_file(
         return out_fname
 
     # identify common groups across all files
-    common_groups = None
+    common_groups: set[str] = set()
     for fname in fnames:
         with h5py.File(fname) as f:
             groups = set(f.keys())
-            common_groups = (
-                groups if common_groups is None else common_groups.intersection(groups)
-            )  # type: ignore
+            common_groups = groups if not common_groups else common_groups.intersection(groups)
 
     if not common_groups:
         raise ValueError("No common groups found across files")

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -61,16 +61,13 @@ def create_virtual_file(
     # check if file already exists
     if not overwrite and out_fname.is_file():
         return out_fname
-    
+
     # identify common groups across all files
     common_groups = None
     for fname in fnames:
         with h5py.File(fname) as f:
             groups = set(f.keys())
-            if common_groups is None:
-                common_groups = groups
-            else:
-                common_groups = common_groups.intersection(groups)
+            common_groups = groups if common_groups is None else common_groups.intersection(groups)
 
     if not common_groups:
         raise ValueError("No common groups found across files")


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* If two h5 files contain groups `A,B,C` in file 1 and A,B in file 2, currently `vds.py` will fail, now it will create a file containing groups `A,B`

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
