### PR TITLE
Add option to set custom flavour yaml path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Add option to set custom flavour yaml path [#65](https://github.com/umami-hep/atlas-ftag-tools/pull/65)
 - Extend working point script to Xbb [#55](https://github.com/umami-hep/atlas-ftag-tools/pull/55)
 ### [v0.1.13]
 - Add common git check functions  [#62](https://github.com/umami-hep/atlas-ftag-tools/pull/62)

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -81,16 +81,19 @@ class FlavourContainer:
         raise KeyError(f"Flavour with {cuts} not found")
 
     @classmethod
-    def from_yaml(cls, yaml_path: Path = None) -> 'FlavourContainer':
+    def from_yaml(cls, yaml_path: Path | None = None) -> FlavourContainer:
         if yaml_path is None:
             yaml_path = Path(__file__).parent / "flavours.yaml"
 
         with open(yaml_path) as f:
             flavours_yaml = yaml.safe_load(f)
-        
-        flavours_dict = {f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml}
+
+        flavours_dict = {
+            f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml
+        }
         assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
 
         return cls(flavours_dict)
+
 
 Flavours = FlavourContainer.from_yaml()

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -43,6 +43,17 @@ class Flavour:
 class FlavourContainer:
     flavours: dict[str, Flavour]
 
+    def __init__(self, yaml_path: Path = None):
+        if yaml_path is None:
+            yaml_path = Path(__file__).parent / "flavours.yaml"
+        with open(yaml_path) as f:
+            flavours_yaml = yaml.safe_load(f)
+        
+        flavours_dict = {f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml}
+        assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
+
+        self.flavours = flavours_dict
+
     def __iter__(self) -> Generator:
         yield from self.flavours.values()
 
@@ -80,9 +91,4 @@ class FlavourContainer:
                 return flavour
         raise KeyError(f"Flavour with {cuts} not found")
 
-
-with open(Path(__file__).parent / "flavours.yaml") as f:
-    flavours_yaml = yaml.safe_load(f)
-flavours_dict = {f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml}
-assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
-Flavours = FlavourContainer(flavours_dict)
+Flavours = FlavourContainer()

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -43,13 +43,15 @@ class Flavour:
 class FlavourContainer:
     flavours: dict[str, Flavour]
 
-    def __init__(self, yaml_path: Path = None):
+    def __init__(self, yaml_path: Path | None = None):
         if yaml_path is None:
             yaml_path = Path(__file__).parent / "flavours.yaml"
         with open(yaml_path) as f:
             flavours_yaml = yaml.safe_load(f)
         
-        flavours_dict = {f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml}
+        flavours_dict = {
+            f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml
+        }
         assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
 
         self.flavours = flavours_dict
@@ -90,5 +92,6 @@ class FlavourContainer:
             if flavour.cuts == cuts:
                 return flavour
         raise KeyError(f"Flavour with {cuts} not found")
+
 
 Flavours = FlavourContainer()

--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -43,19 +43,6 @@ class Flavour:
 class FlavourContainer:
     flavours: dict[str, Flavour]
 
-    def __init__(self, yaml_path: Path | None = None):
-        if yaml_path is None:
-            yaml_path = Path(__file__).parent / "flavours.yaml"
-        with open(yaml_path) as f:
-            flavours_yaml = yaml.safe_load(f)
-        
-        flavours_dict = {
-            f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml
-        }
-        assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
-
-        self.flavours = flavours_dict
-
     def __iter__(self) -> Generator:
         yield from self.flavours.values()
 
@@ -93,5 +80,17 @@ class FlavourContainer:
                 return flavour
         raise KeyError(f"Flavour with {cuts} not found")
 
+    @classmethod
+    def from_yaml(cls, yaml_path: Path = None) -> 'FlavourContainer':
+        if yaml_path is None:
+            yaml_path = Path(__file__).parent / "flavours.yaml"
 
-Flavours = FlavourContainer()
+        with open(yaml_path) as f:
+            flavours_yaml = yaml.safe_load(f)
+        
+        flavours_dict = {f["name"]: Flavour(cuts=Cuts.from_list(f.pop("cuts")), **f) for f in flavours_yaml}
+        assert len(flavours_dict) == len(flavours_yaml), "Duplicate flavour names detected"
+
+        return cls(flavours_dict)
+
+Flavours = FlavourContainer.from_yaml()


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adds an option to set a custom yaml path when creating the `FlavourContainer`. This is necessary for allowing `upp` users to specify custom flavour labeling schemes

Relates to the following issues

* Related to https://github.com/umami-hep/umami-preprocessing/issues/51 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
