### PR TITLE
Bugfix of get_discriminant function

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Bugfix of `get_discriminant` function [#70](https://github.com/umami-hep/atlas-ftag-tools/pull/70)
 - Cache the estimated available jets [#67](https://github.com/umami-hep/atlas-ftag-tools/pull/67)
 - Introduce script to calculate efficiencies and rejections at a given discriminant cut value [#64](https://github.com/umami-hep/atlas-ftag-tools/pull/64)
 

--- a/ftag/wps/discriminant.py
+++ b/ftag/wps/discriminant.py
@@ -58,6 +58,8 @@ def get_discriminant(
     np.ndarray
         Array of discriminant values.
     """
+    if not isinstance(fx, tuple | list):
+        fx = (fx,)
     tagger_funcs = {
         "bjets": btag_discriminant,
         "cjets": ctag_discriminant,


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fix support of only one `fx` value in `get_discriminant` function.

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] ~[Documentation](https://umami-hep.github.io/atlas-ftag-tools/)~
