### PR TITLE
Added ftau to standard b-tagging and c-tagging discriminants

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### [Latest]
+- Add option for tau outputs to b- and c-tagging discriminants [#74](https://github.com/umami-hep/atlas-ftag-tools/pull/74)
 
 ### [v0.1.16.1]
 - Re-release of broken v0.1.16

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -57,20 +57,28 @@ def softmax(x, axis=None):
     return e_x / e_x.sum(axis=axis, keepdims=True)
 
 
-def get_mock_scores(labels: np.ndarray, inc_tau: bool =False):
+def get_mock_scores(labels: np.ndarray, inc_tau: bool = False):
     rng = np.random.default_rng(42)
     nclass = 3 + inc_tau
     scores = np.zeros((len(labels), nclass))
-    
+
     for label, count in zip(*np.unique(labels, return_counts=True)):
         if label == 0:
-            scores[labels == label] = rng.normal(loc=[2, 0, 0] + [0]*inc_tau, scale=1, size=(count, nclass))
+            scores[labels == label] = rng.normal(
+                loc=[2, 0, 0] + [0] * inc_tau, scale=1, size=(count, nclass)
+            )
         elif label == 4:
-            scores[labels == label] = rng.normal(loc=[0, 1, 0] + [0]*inc_tau, scale=2.5, size=(count, nclass))
+            scores[labels == label] = rng.normal(
+                loc=[0, 1, 0] + [0] * inc_tau, scale=2.5, size=(count, nclass)
+            )
         elif label == 5:
-            scores[labels == label] = rng.normal(loc=[0, 0, 3.5] + [0]*inc_tau, scale=5, size=(count, nclass))
+            scores[labels == label] = rng.normal(
+                loc=[0, 0, 3.5] + [0] * inc_tau, scale=5, size=(count, nclass)
+            )
         elif label == 15:
-            scores[labels == label] = rng.normal(loc=[0, 0, 0] + [1]*inc_tau, scale=1, size=(count, nclass))
+            scores[labels == label] = rng.normal(
+                loc=[0, 0, 0] + [1] * inc_tau, scale=1, size=(count, nclass)
+            )
     scores = softmax(scores, axis=1)
     cols = [f"MockTagger_p{x}" for x in ["u", "c", "b"]] + (["MockTagger_ptau"] if inc_tau else [])
 
@@ -99,7 +107,7 @@ def get_mock_file(
     fname: str | None = None,
     tracks_name: str = "tracks",
     num_tracks: int = 40,
-    inc_tau: bool = False
+    inc_tau: bool = False,
 ) -> tuple[str, h5py.File]:
     # setup jets
     rng = np.random.default_rng(42)

--- a/ftag/tests/test_mock.py
+++ b/ftag/tests/test_mock.py
@@ -7,20 +7,25 @@ from ftag.mock import JET_VARS, TRACK_VARS, get_mock_file, get_mock_scores
 
 
 def test_get_mock_scores():
-
     labels = np.array([0, 4, 5] * 10)
     scores = get_mock_scores(labels)
     assert scores.dtype.names == ("MockTagger_pu", "MockTagger_pc", "MockTagger_pb")
     assert scores.shape == (len(labels),)
     assert np.allclose(np.sum(s2u(scores), axis=-1), 1)
 
+
 def test_get_mock_scores_inc_tau():
-    
-        labels = np.array([0, 4, 5, 15] * 10)
-        scores = get_mock_scores(labels, inc_tau=True)
-        assert scores.dtype.names == ("MockTagger_pu", "MockTagger_pc", "MockTagger_pb", "MockTagger_ptau")
-        assert scores.shape == (len(labels),)
-        assert np.allclose(np.sum(s2u(scores), axis=-1), 1)
+    labels = np.array([0, 4, 5, 15] * 10)
+    scores = get_mock_scores(labels, inc_tau=True)
+    assert scores.dtype.names == (
+        "MockTagger_pu",
+        "MockTagger_pc",
+        "MockTagger_pb",
+        "MockTagger_ptau",
+    )
+    assert scores.shape == (len(labels),)
+    assert np.allclose(np.sum(s2u(scores), axis=-1), 1)
+
 
 def test_get_mock_file():
     # test jets are correctly generated
@@ -60,6 +65,7 @@ def test_get_mock_file():
     # test custom fname
     fname, f = get_mock_file(fname="test.h5")
     assert fname == "test.h5"
+
 
 def test_get_mock_file_inc_taus():
     # test jets are correctly generated

--- a/ftag/tests/test_mock.py
+++ b/ftag/tests/test_mock.py
@@ -7,16 +7,24 @@ from ftag.mock import JET_VARS, TRACK_VARS, get_mock_file, get_mock_scores
 
 
 def test_get_mock_scores():
+
     labels = np.array([0, 4, 5] * 10)
     scores = get_mock_scores(labels)
     assert scores.dtype.names == ("MockTagger_pu", "MockTagger_pc", "MockTagger_pb")
     assert scores.shape == (len(labels),)
     assert np.allclose(np.sum(s2u(scores), axis=-1), 1)
 
+def test_get_mock_scores_inc_tau():
+    
+        labels = np.array([0, 4, 5, 15] * 10)
+        scores = get_mock_scores(labels, inc_tau=True)
+        assert scores.dtype.names == ("MockTagger_pu", "MockTagger_pc", "MockTagger_pb", "MockTagger_ptau")
+        assert scores.shape == (len(labels),)
+        assert np.allclose(np.sum(s2u(scores), axis=-1), 1)
 
 def test_get_mock_file():
     # test jets are correctly generated
-    fname, f = get_mock_file(num_jets=1000)
+    fname, f = get_mock_file(num_jets=1000, inc_tau=False)
     jets = f["jets"]
     assert len(jets) == 1000
     assert set(jets.dtype.names) == set(
@@ -52,3 +60,22 @@ def test_get_mock_file():
     # test custom fname
     fname, f = get_mock_file(fname="test.h5")
     assert fname == "test.h5"
+
+def test_get_mock_file_inc_taus():
+    # test jets are correctly generated
+    fname, f = get_mock_file(num_jets=1000, inc_tau=True)
+    jets = f["jets"]
+    assert len(jets) == 1000
+    assert set(jets.dtype.names) == set(
+        [name for name, dtype in JET_VARS]
+        + [
+            "MockTagger_pu",
+            "MockTagger_pc",
+            "MockTagger_pb",
+            "MockTagger_ptau",
+            "MockXbbTagger_phbb",
+            "MockXbbTagger_phcc",
+            "MockXbbTagger_ptop",
+            "MockXbbTagger_pqcd",
+        ]
+    )

--- a/ftag/tests/wps/test_discriminant.py
+++ b/ftag/tests/wps/test_discriminant.py
@@ -30,39 +30,48 @@ def test_btag_discriminant():
     expected = np.log((pb + epsilon) / ((1.0 - fc) * pu + fc * pc + epsilon))
     assert np.allclose(disc, expected)
 
+
 def test_btag_discriminant_inc_tau():
     jets = np.array(
-    [
-        (0.2, 0.3, 0.9, 0.1),
-        (0.8, 0.5, 0.1, 0.2),
-        (0.6, 0.1, 0.7, 0.3),
-    ],
-    dtype=[("tagger_pb", "f4"), ("tagger_pc", "f4"), ("tagger_pu", "f4"), ("tagger_ptau", "f4")],
+        [
+            (0.2, 0.3, 0.9, 0.1),
+            (0.8, 0.5, 0.1, 0.2),
+            (0.6, 0.1, 0.7, 0.3),
+        ],
+        dtype=[
+            ("tagger_pb", "f4"),
+            ("tagger_pc", "f4"),
+            ("tagger_pu", "f4"),
+            ("tagger_ptau", "f4"),
+        ],
     )
     tagger = "tagger"
     fc = 0.1
-    
+
     epsilon = 1e-10
     for ftau in (0, 0.2):
         disc = btag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
-        pb, pc, pu, ptau = [ jets[f"{tagger}_p{f}" ] for f in ("b", "c", "u", "tau") ]
-        expected = np.log((pb + epsilon) / ((1.0 - fc - ftau) * pu + fc * pc + ftau*ptau + epsilon))
+        pb, pc, pu, ptau = (jets[f"{tagger}_p{f}"] for f in ("b", "c", "u", "tau"))
+        expected = np.log(
+            (pb + epsilon) / ((1.0 - fc - ftau) * pu + fc * pc + ftau * ptau + epsilon)
+        )
     assert np.allclose(disc, expected)
+
 
 def test_no_tau_with_ftau():
     jets = np.array(
-    [
-        (0.2, 0.3, 0.9),
-        (0.8, 0.5, 0.1),
-        (0.6, 0.1, 0.7),
-    ],
-    dtype=[("tagger_pb", "f4"), ("tagger_pc", "f4"), ("tagger_pu", "f4")],
+        [
+            (0.2, 0.3, 0.9),
+            (0.8, 0.5, 0.1),
+            (0.6, 0.1, 0.7),
+        ],
+        dtype=[("tagger_pb", "f4"), ("tagger_pc", "f4"), ("tagger_pu", "f4")],
     )
     tagger = "tagger"
     fc = 0.1
-    ftau=0.2
+    ftau = 0.2
     epsilon = 1e-10
-    
+
     with pytest.raises(ValueError):
         btag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
     with pytest.raises(ValueError):
@@ -168,4 +177,3 @@ def test_get_discriminant():
     # test invalid signal flavour
     with pytest.raises(ValueError):
         get_discriminant(jets, tagger, Flavours.hbb, (0.1,), epsilon=1e-10)
-

--- a/ftag/tests/wps/test_discriminant.py
+++ b/ftag/tests/wps/test_discriminant.py
@@ -25,10 +25,48 @@ def test_btag_discriminant():
     tagger = "tagger"
     fc = 0.1
     epsilon = 1e-10
-    disc = btag_discriminant(jets, tagger, fc, epsilon)
+    disc = btag_discriminant(jets, tagger, fc, epsilon=epsilon)
     pb, pc, pu = jets[f"{tagger}_pb"], jets[f"{tagger}_pc"], jets[f"{tagger}_pu"]
     expected = np.log((pb + epsilon) / ((1.0 - fc) * pu + fc * pc + epsilon))
     assert np.allclose(disc, expected)
+
+def test_btag_discriminant_inc_tau():
+    jets = np.array(
+    [
+        (0.2, 0.3, 0.9, 0.1),
+        (0.8, 0.5, 0.1, 0.2),
+        (0.6, 0.1, 0.7, 0.3),
+    ],
+    dtype=[("tagger_pb", "f4"), ("tagger_pc", "f4"), ("tagger_pu", "f4"), ("tagger_ptau", "f4")],
+    )
+    tagger = "tagger"
+    fc = 0.1
+    
+    epsilon = 1e-10
+    for ftau in (0, 0.2):
+        disc = btag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
+        pb, pc, pu, ptau = [ jets[f"{tagger}_p{f}" ] for f in ("b", "c", "u", "tau") ]
+        expected = np.log((pb + epsilon) / ((1.0 - fc - ftau) * pu + fc * pc + ftau*ptau + epsilon))
+    assert np.allclose(disc, expected)
+
+def test_no_tau_with_ftau():
+    jets = np.array(
+    [
+        (0.2, 0.3, 0.9),
+        (0.8, 0.5, 0.1),
+        (0.6, 0.1, 0.7),
+    ],
+    dtype=[("tagger_pb", "f4"), ("tagger_pc", "f4"), ("tagger_pu", "f4")],
+    )
+    tagger = "tagger"
+    fc = 0.1
+    ftau=0.2
+    epsilon = 1e-10
+    
+    with pytest.raises(ValueError):
+        btag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
+    with pytest.raises(ValueError):
+        ctag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
 
 
 def test_ctag_discriminant():
@@ -43,7 +81,7 @@ def test_ctag_discriminant():
     tagger = "tagger"
     fb = 0.2
     epsilon = 1e-10
-    disc = ctag_discriminant(jets, tagger, fb, epsilon)
+    disc = ctag_discriminant(jets, tagger, fb, epsilon=epsilon)
     pb, pc, pu = jets[f"{tagger}_pb"], jets[f"{tagger}_pc"], jets[f"{tagger}_pu"]
     expected = np.log((pc + epsilon) / ((1.0 - fb) * pu + fb * pb + epsilon))
     assert np.allclose(disc, expected)
@@ -130,3 +168,4 @@ def test_get_discriminant():
     # test invalid signal flavour
     with pytest.raises(ValueError):
         get_discriminant(jets, tagger, Flavours.hbb, (0.1,), epsilon=1e-10)
+

--- a/ftag/tests/wps/test_working_points.py
+++ b/ftag/tests/wps/test_working_points.py
@@ -13,10 +13,11 @@ from ftag.wps.working_points import main
 def ttbar_file():
     yield get_mock_file(10_000)[0]
 
+
 @pytest.fixture
 def ttbar_inc_tau_file():
     f = get_mock_file(10_000, inc_tau=True)
-    print(f[1]['jets'].dtype.names)
+    print(f[1]["jets"].dtype.names)
     yield get_mock_file(10_000, inc_tau=True)[0]
 
 
@@ -145,6 +146,7 @@ def test_get_working_points_zprime(ttbar_file, zprime_file, eff_val="60"):
         float(eff_val) / 100, rel=1e-2
     )
 
+
 def test_get_working_points_inc_tau(ttbar_inc_tau_file, eff_val="60"):
     args = [
         "--ttbar",
@@ -172,6 +174,7 @@ def test_get_working_points_inc_tau(ttbar_inc_tau_file, eff_val="60"):
     assert output["MockTagger"][eff_val]["ttbar"]["eff"]["bjets"] == pytest.approx(
         float(eff_val) / 100, rel=1e-2
     )
+
 
 def test_get_working_points_xbb(ttbar_file, eff_val="60"):
     # Assuming you're testing with two fx values for each tagger as required for Xbb
@@ -242,7 +245,10 @@ def test_get_rej_eff_at_disc_ttbar(ttbar_file, disc_vals=None):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "bjets"
-    assert output["MockTagger"]["fx"] == (0.01, 0, )
+    assert output["MockTagger"]["fx"] == (
+        0.01,
+        0,
+    )
     assert "ttbar" in output["MockTagger"]
     ttbar = output["MockTagger"]["ttbar"]
     for dval in disc_vals:

--- a/ftag/tests/wps/test_working_points.py
+++ b/ftag/tests/wps/test_working_points.py
@@ -13,6 +13,12 @@ from ftag.wps.working_points import main
 def ttbar_file():
     yield get_mock_file(10_000)[0]
 
+@pytest.fixture
+def ttbar_inc_tau_file():
+    f = get_mock_file(10_000, inc_tau=True)
+    print(f[1]['jets'].dtype.names)
+    yield get_mock_file(10_000, inc_tau=True)[0]
+
 
 @pytest.fixture
 def zprime_file():
@@ -36,7 +42,7 @@ def test_get_working_points(ttbar_file, eff_val="60"):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "bjets"
-    assert output["MockTagger"]["fx"] == (0.01,)
+    assert output["MockTagger"]["fx"] == (0.01, 0)
     assert eff_val in output["MockTagger"]
     assert "cut_value" in output["MockTagger"][eff_val]
     assert "ttbar" in output["MockTagger"][eff_val]
@@ -66,7 +72,7 @@ def test_get_working_points_rejection(ttbar_file, rej_val="100"):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "bjets"
-    assert output["MockTagger"]["fx"] == (0.01,)
+    assert output["MockTagger"]["fx"] == (0.01, 0)
     assert rej_val in output["MockTagger"]
     assert "cut_value" in output["MockTagger"][rej_val]
     assert "ttbar" in output["MockTagger"][rej_val]
@@ -96,7 +102,7 @@ def test_get_working_points_cjets(ttbar_file, eff_val="60"):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "cjets"
-    assert output["MockTagger"]["fx"] == (0.01,)
+    assert output["MockTagger"]["fx"] == (0.01, 0)
     assert eff_val in output["MockTagger"]
     assert "cut_value" in output["MockTagger"][eff_val]
     assert "ttbar" in output["MockTagger"][eff_val]
@@ -126,7 +132,7 @@ def test_get_working_points_zprime(ttbar_file, zprime_file, eff_val="60"):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "bjets"
-    assert output["MockTagger"]["fx"] == (0.15,)
+    assert output["MockTagger"]["fx"] == (0.15, 0)
     assert eff_val in output["MockTagger"]
     assert "cut_value" in output["MockTagger"][eff_val]
     assert "ttbar" in output["MockTagger"][eff_val]
@@ -139,6 +145,33 @@ def test_get_working_points_zprime(ttbar_file, zprime_file, eff_val="60"):
         float(eff_val) / 100, rel=1e-2
     )
 
+def test_get_working_points_inc_tau(ttbar_inc_tau_file, eff_val="60"):
+    args = [
+        "--ttbar",
+        str(ttbar_inc_tau_file),
+        "-t",
+        "MockTagger",
+        "-f",
+        "0.01",
+        "0.02",
+        "-e",
+        eff_val,
+        "-n",
+        "10_000",
+    ]
+    output = main(args)
+
+    assert "MockTagger" in output
+    assert output["MockTagger"]["signal"] == "bjets"
+    assert output["MockTagger"]["fx"] == (0.01, 0.02)
+    assert eff_val in output["MockTagger"]
+    assert "cut_value" in output["MockTagger"][eff_val]
+    assert "ttbar" in output["MockTagger"][eff_val]
+    assert "eff" in output["MockTagger"][eff_val]["ttbar"]
+    assert "rej" in output["MockTagger"][eff_val]["ttbar"]
+    assert output["MockTagger"][eff_val]["ttbar"]["eff"]["bjets"] == pytest.approx(
+        float(eff_val) / 100, rel=1e-2
+    )
 
 def test_get_working_points_xbb(ttbar_file, eff_val="60"):
     # Assuming you're testing with two fx values for each tagger as required for Xbb
@@ -180,14 +213,14 @@ def test_get_working_points_xbb(ttbar_file, eff_val="60"):
 def test_get_working_points_fx_length_check():
     # test with incorrect length of fx values for regular b-tagging
     with pytest.raises(ValueError):
-        main(["--ttbar", "path", "-t", "MockTagger", "-f", "0.1", "0.2"])
+        main(["--ttbar", "path", "-t", "MockTagger", "-f", "0.1", "0.2", "0.3"])
 
     # test with incorrect length of fx values for Xbb tagging
     with pytest.raises(ValueError):
         main(["--ttbar", "path", "--xbb", "-t", "MockXbbTagger", "-f", "0.25"])
 
     with pytest.raises(ValueError):
-        main(["--ttbar", "path", "-t", "MockTagger", "-f", "0.1", "0.2", "-d", "1.0"])
+        main(["--ttbar", "path", "-t", "MockTagger", "-f", "0.1", "0.2", "0.3", "-d", "1.0"])
 
 
 def test_get_rej_eff_at_disc_ttbar(ttbar_file, disc_vals=None):
@@ -209,7 +242,7 @@ def test_get_rej_eff_at_disc_ttbar(ttbar_file, disc_vals=None):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "bjets"
-    assert output["MockTagger"]["fx"] == (0.01,)
+    assert output["MockTagger"]["fx"] == (0.01, 0, )
     assert "ttbar" in output["MockTagger"]
     ttbar = output["MockTagger"]["ttbar"]
     for dval in disc_vals:
@@ -241,7 +274,7 @@ def test_get_rej_eff_at_disc_zprime(ttbar_file, zprime_file, disc_vals=None):
 
     assert "MockTagger" in output
     assert output["MockTagger"]["signal"] == "bjets"
-    assert output["MockTagger"]["fx"] == (0.01,)
+    assert output["MockTagger"]["fx"] == (0.01, 0)
     assert "ttbar" in output["MockTagger"]
     assert "zprime" in output["MockTagger"]
 

--- a/ftag/wps/discriminant.py
+++ b/ftag/wps/discriminant.py
@@ -5,14 +5,24 @@ import numpy as np
 from ftag.flavour import Flavour, Flavours
 
 
-def btag_discriminant(jets, tagger, fc=0.1, epsilon=1e-10):
+def btag_discriminant(jets, tagger, fc=0.1, ftau=0, epsilon=1e-10):
     pb, pc, pu = (jets[f"{tagger}_pb"], jets[f"{tagger}_pc"], jets[f"{tagger}_pu"])
-    return np.log((pb + epsilon) / ((1.0 - fc) * pu + fc * pc + epsilon))
+    ptau = jets[f"{tagger}_ptau"] if f"{tagger}_ptau" in jets.dtype.names else 0
+    if ftau > 0 and ptau == 0:
+        raise ValueError(
+            "Selected non zero ftau, but no tau probabilities found in the input array."
+        )
+    return np.log((pb + epsilon) / ((1.0 - fc - ftau) * pu + fc * pc + ftau * ptau + epsilon))
 
 
-def ctag_discriminant(jets, tagger, fb=0.2, epsilon=1e-10):
+def ctag_discriminant(jets, tagger, fb=0.2, ftau=0, epsilon=1e-10):
     pb, pc, pu = (jets[f"{tagger}_pb"], jets[f"{tagger}_pc"], jets[f"{tagger}_pu"])
-    return np.log((pc + epsilon) / ((1.0 - fb) * pu + fb * pb + epsilon))
+    ptau = jets[f"{tagger}_ptau"] if f"{tagger}_ptau" in jets.dtype.names else 0
+    if ftau > 0 and ptau == 0:
+        raise ValueError(
+            "Selected non zero ftau, but no tau probabilities found in the input array."
+        )
+    return np.log((pc + epsilon) / ((1.0 - fb - ftau) * pu + fb * pb + ftau * ptau + epsilon))
 
 
 def hbb_discriminant(jets, tagger, ftop=0.25, fhcc=0.02, epsilon=1e-10):

--- a/ftag/wps/discriminant.py
+++ b/ftag/wps/discriminant.py
@@ -8,7 +8,7 @@ from ftag.flavour import Flavour, Flavours
 def btag_discriminant(jets, tagger, fc=0.1, ftau=0, epsilon=1e-10):
     pb, pc, pu = (jets[f"{tagger}_pb"], jets[f"{tagger}_pc"], jets[f"{tagger}_pu"])
     ptau = jets[f"{tagger}_ptau"] if f"{tagger}_ptau" in jets.dtype.names else 0
-    if ftau > 0 and ptau == 0:
+    if ftau > 0 and isinstance(ptau, int):
         raise ValueError(
             "Selected non zero ftau, but no tau probabilities found in the input array."
         )
@@ -18,7 +18,7 @@ def btag_discriminant(jets, tagger, fc=0.1, ftau=0, epsilon=1e-10):
 def ctag_discriminant(jets, tagger, fb=0.2, ftau=0, epsilon=1e-10):
     pb, pc, pu = (jets[f"{tagger}_pb"], jets[f"{tagger}_pc"], jets[f"{tagger}_pu"])
     ptau = jets[f"{tagger}_ptau"] if f"{tagger}_ptau" in jets.dtype.names else 0
-    if ftau > 0 and ptau == 0:
+    if ftau > 0 and isinstance(ptau, int):
         raise ValueError(
             "Selected non zero ftau, but no tau probabilities found in the input array."
         )
@@ -81,4 +81,4 @@ def get_discriminant(
     if func is None:
         raise ValueError(f"Signal flavour must be among {list(tagger_funcs.keys())}, not {signal}")
 
-    return func(jets, tagger, *fx, epsilon)  # type: ignore
+    return func(jets, tagger, *fx, epsilon=epsilon)  # type: ignore


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Allows for discriminant calculations to include ptau and ftau
* By default, ftau is 0, and ptau is only extracted from provided file if it exists
* Adds option to include ptau in mock file 

closes #69 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
