### PR TITLE
Added new flavour for ghost association labelling

### DIFF
--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -47,6 +47,28 @@
   colour: gold
   category: single-btag-extended
 
+# single b-tagging (ghost association)
+- name: ghostbjets
+  label: $b$-jets
+  cuts: ["HadronGhostTruthLabelID == 5"]
+  colour: tab:blue
+  category: single-btag-ghost
+- name: ghostcjets
+  label: $c$-jets
+  cuts: ["HadronGhostTruthLabelID == 4"]
+  colour: tab:orange
+  category: single-btag-ghost
+- name: ghostujets
+  label: Light-jets
+  cuts: ["HadronGhostTruthLabelID == 0"]
+  colour: tab:green
+  category: single-btag-ghost
+- name: ghosttaujets
+  label: $\tau$-jets
+  cuts: ["HadronGhostTruthLabelID == 15"]
+  colour: tab:purple
+  category: single-btag-ghost
+
 # Xbb tagging
 - name: hbb
   label: $H \rightarrow b\bar{b}$

--- a/ftag/tests/test_flavour.py
+++ b/ftag/tests/test_flavour.py
@@ -60,6 +60,7 @@ def test_Flavours_categories():
     target = [
         "single-btag",
         "single-btag-extended",
+        "single-btag-ghost",
         "xbb",
         "xbb-extended",
         "partonic",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Added new flavour class for ghost association labelling


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
