### PR TITLE
Fix precision setting for H5Writer

### DIFF
--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -87,7 +87,7 @@ class H5Writer:
         # adjust dtype based on specified precision
         dtype = np.dtype([
             (field, self.fp_dtype if np.issubdtype(dt, np.floating) else dt)
-            for field, dt in dtype.fields.items()
+            for field, dt in dtype.descr
         ])
 
         # optimal chunking is around 100 jets, only aply for track groups

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -41,7 +41,7 @@ class H5Writer:
     jets_name: str = "jets"
     add_flavour_label: bool = False
     compression: str = "lzf"
-    precision: str | None = None
+    precision: str = "full"
     shuffle: bool = True
 
     def __post_init__(self):


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Write datasets with specified precision

@nikitapond 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
