### PR TITLE
Add tool to generate labels on the fly

### DIFF
--- a/ftag/flavour.py
+++ b/ftag/flavour.py
@@ -42,6 +42,9 @@ class Flavour:
     def __str__(self) -> str:
         return self.name
 
+    def __lt__(self, other) -> bool:
+        return self.name < other.name
+
 
 @dataclass
 class FlavourContainer:
@@ -81,7 +84,10 @@ class FlavourContainer:
         return list(dict.fromkeys(f.category for f in self))
 
     def by_category(self, category: str) -> FlavourContainer:
-        return FlavourContainer({k: v for k, v in self.flavours.items() if v.category == category})
+        f = FlavourContainer({k: v for k, v in self.flavours.items() if v.category == category})
+        if not f.flavours:
+            raise KeyError(f"No flavours with category '{category}' found")
+        return f
 
     def from_cuts(self, cuts: list | Cuts) -> Flavour:
         if isinstance(cuts, list):

--- a/ftag/labeller.py
+++ b/ftag/labeller.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ftag import Flavours
+from ftag.flavour import Flavour, FlavourContainer
+from ftag.hdf5 import join_structured_arrays, structured_from_dict
+
+
+@dataclass
+class Labeller:
+    """
+    Defines a labelling scheme.
+
+    Labels are [0, ..., n] and are assigned using pre-defined selections.
+
+    Parameters
+    ----------
+    labels : FlavourContainer | list[str | Flavour]
+        The labels to be labelled.
+    require_labels : bool
+        Whether to require that all objects are labelled.
+    """
+
+    labels: FlavourContainer | list[str | Flavour]
+    require_labels: bool = True
+
+    def __post_init__(self):
+        if isinstance(self.labels, FlavourContainer):
+            self.labels = list(self.labels)
+        self.labels = sorted([Flavours[label] for label in self.labels])
+
+    def get_labels(self, array: np.ndarray) -> np.ndarray:
+        """
+        Returns the labels for the given array.
+
+        Parameters
+        ----------
+        array : np.ndarray
+            The array to label.
+
+        Returns
+        -------
+        np.ndarray
+            The labels for the given array.
+
+        Raises
+        ------
+        ValueError
+            If the `require_labels` attribute is set to `True` and some objects were not labelled.
+        """
+        labels = -1 * np.ones_like(array, dtype=int)
+        for i, label in enumerate(self.labels):
+            labels[label.cuts(array).idx] = i
+
+        if self.require_labels and -1 in labels:
+            raise ValueError("Some objects were not labelled")
+
+        return labels[labels != -1]
+
+    def add_labels(self, array: np.ndarray, label_name: str = "labels") -> np.ndarray:
+        """
+        Adds the labels to the given array.
+
+        Parameters
+        ----------
+        array : np.ndarray
+            The array to label.
+        label_name : str
+            The name of the label column.
+
+        Returns
+        -------
+        np.ndarray
+            The array with the labels added.
+
+        Raises
+        ------
+        ValueError
+            If the `require_labels` attribute is set to `False`.
+        """
+        if not self.require_labels:
+            raise ValueError("Cannot add labels if require_labels is set to False")
+        labels = self.get_labels(array)
+        labels = structured_from_dict({label_name: labels})
+        return join_structured_arrays([array, labels])

--- a/ftag/labeller.py
+++ b/ftag/labeller.py
@@ -19,7 +19,7 @@ class Labeller:
     Parameters
     ----------
     labels : FlavourContainer | list[str | Flavour]
-        The labels to be labelled.
+        The labels to be use.
     require_labels : bool
         Whether to require that all objects are labelled.
     """
@@ -27,7 +27,7 @@ class Labeller:
     labels: FlavourContainer | list[str | Flavour]
     require_labels: bool = True
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.labels, FlavourContainer):
             self.labels = list(self.labels)
         self.labels = sorted([Flavours[label] for label in self.labels])

--- a/ftag/tests/test_labeller.py
+++ b/ftag/tests/test_labeller.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ftag import Flavour, Flavours
+from ftag.labeller import Labeller
+from ftag.mock import mock_jets
+
+
+# make a pytest fixture to return jets using mock data
+@pytest.fixture
+def jets():
+    return mock_jets(1000)
+
+
+def test_initialization():
+    flavours = Flavours.by_category("single-btag")
+    labeller = Labeller(flavours)
+    assert len(labeller.labels) == 4
+    assert all(isinstance(f, Flavour) for f in labeller.labels)
+
+    flavours = ["bjets", "cjets"]
+    labeller = Labeller(flavours)
+    assert len(labeller.labels) == 2
+    assert all(isinstance(f, Flavour) for f in labeller.labels)
+
+    with pytest.raises(KeyError, match="Flavour 'nonexistent' not found"):
+        Labeller(["nonexistent"])
+
+
+def test_get_labels_valid_input(jets):
+    flavours = ["bjets", "cjets", "ujets", "taujets"]
+    labeller = Labeller(flavours)
+    labels = labeller.get_labels(jets)
+
+    expected = np.zeros(len(jets), dtype=int)
+    expected[jets["HadronConeExclTruthLabelID"] == 5] = 0
+    expected[jets["HadronConeExclTruthLabelID"] == 4] = 1
+    expected[jets["HadronConeExclTruthLabelID"] == 15] = 2
+    expected[jets["HadronConeExclTruthLabelID"] == 0] = 3
+
+    assert np.array_equal(labels, expected)
+
+
+def test_get_labels_unlabelled_objects(jets):
+    flavours = ["bjets"]
+    labeller = Labeller(flavours, require_labels=True)
+    with pytest.raises(ValueError, match="Some objects were not labelled"):
+        labeller.get_labels(jets)
+
+    labeller = Labeller(flavours, require_labels=False)
+    labels = labeller.get_labels(jets)
+    sel_jets = jets[jets["HadronConeExclTruthLabelID"] == 5]
+    assert len(labels) == len(sel_jets)
+    assert np.all(labels == 0)
+
+
+def test_add_labels(jets):
+    flavours = ["bjets", "cjets", "ujets", "taujets"]
+    labeller = Labeller(flavours)
+    jets = labeller.add_labels(jets)
+    labels = labeller.get_labels(jets)
+    assert np.array_equal(jets["labels"], labels)
+
+    labeller = Labeller(flavours, require_labels=False)
+    with pytest.raises(ValueError, match="Cannot add labels if require_labels is set to False"):
+        labeller.add_labels(jets)


### PR DESCRIPTION
## Summary

Add a tool to generate labels on the fly

* We could use this during resampling (not done here)
* More interesting: we could use this on the fly during training

Relates to the following issues


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
