### PR TITLE
Add track selector class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,12 +3,11 @@
     "autoDocstring.docstringFormat": "numpy",
     "[python]": {
         "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true,
-            "source.fixAll": true
+            "source.fixAll": "explicit"
         },
     },
-    "editor.formatOnSave": true,
     "files.watcherExclude": {
         "**/.git/objects/**": true,
         "**/.git/subtree-cache/**": true,

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ### [Latest]
 
--  Add tool to generate labels on the fly [#87](https://github.com/umami-hep/atlas-ftag-tools/pull/87)
+- Add track selector class based on cuts [#89](https://github.com/umami-hep/atlas-ftag-tools/pull/89)
+- Add tool to generate labels on the fly [#87](https://github.com/umami-hep/atlas-ftag-tools/pull/87)
 
 ### [v0.2.2]
 

--- a/ftag/cuts.py
+++ b/ftag/cuts.py
@@ -79,7 +79,9 @@ class Cuts:
     def ignore(self, variables: list[str]):
         return Cuts(tuple(c for c in self if c.variable not in variables))
 
-    def __call__(self, array) -> CutsResult:
+    def __call__(self, array: np.ndarray) -> CutsResult:
+        if array.ndim == 2:
+            raise ValueError("This interface only supports jet selections")
         keep = np.arange(len(array))
         for cut in self.cuts:
             idx = cut(array)

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -108,6 +108,7 @@ def mock_tracks(num_jets=1000, num_tracks=40) -> np.ndarray:
     rng = np.random.default_rng(42)
     tracks_dtype = np.dtype(TRACK_VARS)
     tracks = u2s(rng.random((num_jets, num_tracks, len(TRACK_VARS))), tracks_dtype)
+    tracks["d0"] *= 5
     valid = rng.choice([True, False], size=(num_jets, num_tracks))
     valid = valid.astype(bool).view(dtype=np.dtype([("valid", bool)]))
     return join_structured_arrays([tracks, valid])

--- a/ftag/tests/test_cuts.py
+++ b/ftag/tests/test_cuts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from ftag.cuts import Cut, Cuts, CutsResult
 
@@ -55,3 +56,10 @@ def test_Cuts_getitem_method():
     c_x = c["x"]
     assert len(c_x) == 2
     assert all(c.variable == "x" for c in c_x)
+
+
+def test_Cuts_ndim_error():
+    c = Cuts.from_list([("x", "==", "1")])
+    array = np.ones((2, 2))
+    with pytest.raises(ValueError, match="This interface only supports jet selections"):
+        c(array)

--- a/ftag/tests/test_track_selector.py
+++ b/ftag/tests/test_track_selector.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ftag import Cuts
+from ftag.mock import mock_tracks
+from ftag.track_selector import TrackSelector
+
+
+def test_selector_no_cuts():
+    tracks = mock_tracks()
+    cuts = Cuts.empty()
+    selector = TrackSelector(cuts)
+    selected = selector(tracks.copy())
+    assert np.all(selected == tracks)
+
+
+def test_selector_keep_all():
+    tracks = mock_tracks()
+    cuts = Cuts.from_list(["d0 > 0"])
+    selector = TrackSelector(cuts)
+    selected = selector(tracks.copy())
+    assert np.all(selected == tracks)
+
+
+def test_selector_remove_all():
+    tracks = mock_tracks()
+    init_valid = tracks["valid"].copy()
+    cuts = Cuts.from_list(["numberOfPixelHits < -999"])
+    selector = TrackSelector(cuts)
+    selected = selector(tracks.copy())
+    selected = selected[init_valid]
+    for var in tracks.dtype.names:
+        if issubclass(tracks[var].dtype.type, np.floating):
+            print(selected[var])
+            assert np.all(np.isnan(selected[var]))
+        elif issubclass(tracks[var].dtype.type, np.integer):
+            assert np.all(selected[var] == -1)
+        elif issubclass(tracks[var].dtype.type, np.bool_):
+            assert np.all(~selected[var])
+
+
+def test_selector_remove_some():
+    tracks = mock_tracks()
+    assert np.any(tracks[tracks["valid"]]["d0"] > 3.5)
+    cuts = Cuts.from_list(["d0 < 3.5"])
+    init_valid = tracks["valid"].copy()
+    init_d0 = tracks["d0"].copy()
+    selector = TrackSelector(cuts)
+    selected = selector(tracks)
+    idx = init_valid & (init_d0 > 3.5)
+    assert np.all(np.isnan(selected[idx]["d0"]))
+    assert np.all(selected[selected["valid"]]["d0"] < 3.5)

--- a/ftag/track_selector.py
+++ b/ftag/track_selector.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ftag import Cuts
+
+
+@dataclass
+class TrackSelector:
+    """
+    Apply track selections to a set of tracks stored in a structured numpy array.
+
+    The array is assumed to have shape (n_jets, n_tracks, n_features).
+    Applying cuts will NaN out the tracks that do not pass the cuts,
+    but leave the shape of the array unchanged.
+
+    Parameters
+    ----------
+    cuts : Cuts
+        The cuts to apply to the tracks
+    valid_str : str
+        The name of the field in the tracks that indicates whether the track is
+    """
+
+    cuts: Cuts
+    valid_str: str = "valid"
+
+    def __call__(self, tracks: np.ndarray) -> np.ndarray:
+        # get a bool array for all tracks passing before any cuts
+        rm_idx = np.zeros_like(tracks[self.valid_str], dtype=bool)
+
+        # apply the cuts
+        for cut in self.cuts.cuts:
+            # remove valid track indices that do not pass the selection
+            rm_idx[tracks[self.valid_str] & ~cut(tracks)] = True
+
+        # set the values of the tracks that do not pass the cuts to
+        for var in tracks.dtype.names:
+            if issubclass(tracks[var].dtype.type, np.floating):
+                tracks[var][rm_idx] = np.nan
+            elif issubclass(tracks[var].dtype.type, np.integer):
+                tracks[var][rm_idx] = -1
+            elif issubclass(tracks[var].dtype.type, np.bool_):
+                tracks[var][rm_idx] = False
+            else:
+                raise TypeError(f"Unknown dtype {tracks[var].dtype}")
+
+        # specifically set the valid flag to false (even though it's already false by now)
+        tracks[rm_idx][self.valid_str] = False
+
+        return tracks


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

closes https://github.com/umami-hep/atlas-ftag-tools/issues/3

used here in UPP https://github.com/umami-hep/umami-preprocessing/pull/68

could also be used in dataloading in salt


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
