### PR TITLE
Custom nshared cut for tracks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Add nshared selection to track selector [#90](https://github.com/umami-hep/atlas-ftag-tools/pull/90)
+
 ### [v0.2.3]
 
 - Add track selector class based on cuts [#89](https://github.com/umami-hep/atlas-ftag-tools/pull/89)

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -109,6 +109,11 @@ def mock_tracks(num_jets=1000, num_tracks=40) -> np.ndarray:
     tracks_dtype = np.dtype(TRACK_VARS)
     tracks = u2s(rng.random((num_jets, num_tracks, len(TRACK_VARS))), tracks_dtype)
     tracks["d0"] *= 5
+
+    # for the shared hits, add some reasonable integer values
+    tracks["numberOfPixelSharedHits"] = rng.integers(0, 3, size=(num_jets, num_tracks))
+    tracks["numberOfSCTSharedHits"] = rng.integers(0, 3, size=(num_jets, num_tracks))
+
     valid = rng.choice([True, False], size=(num_jets, num_tracks))
     valid = valid.astype(bool).view(dtype=np.dtype([("valid", bool)]))
     return join_structured_arrays([tracks, valid])

--- a/ftag/tests/test_track_selector.py
+++ b/ftag/tests/test_track_selector.py
@@ -68,5 +68,11 @@ def test_nshared_cut():
     n_sct_shared = tracks["numberOfSCTSharedHits"]
     n_module_shared = n_pix_shared + n_sct_shared / 2
 
-    print(n_module_shared[selected["valid"]])
     assert not np.any(n_module_shared[selected["valid"]] > 1)
+
+    # check an error is raised if NSHARED is already a track variable
+    with np.testing.assert_raises(ValueError):
+        cut = Cuts.from_list(["NSHARED < 1.1"])
+        tracks["NSHARED"] = 0
+        selector = TrackSelector(cut)
+        selector(tracks.copy())

--- a/ftag/tests/test_track_selector.py
+++ b/ftag/tests/test_track_selector.py
@@ -51,3 +51,22 @@ def test_selector_remove_some():
     idx = init_valid & (init_d0 > 3.5)
     assert np.all(np.isnan(selected[idx]["d0"]))
     assert np.all(selected[selected["valid"]]["d0"] < 3.5)
+
+
+def test_nshared_cut():
+    tracks = mock_tracks()
+
+    n_pix_shared = tracks["numberOfPixelSharedHits"]
+    n_sct_shared = tracks["numberOfSCTSharedHits"]
+    n_module_shared = n_pix_shared + n_sct_shared / 2
+    assert np.any(n_module_shared[tracks["valid"]] > 1)
+
+    cut = Cuts.from_list(["NSHARED < 1.1"])
+    selector = TrackSelector(cut)
+    selected = selector(tracks.copy())
+    n_pix_shared = tracks["numberOfPixelSharedHits"]
+    n_sct_shared = tracks["numberOfSCTSharedHits"]
+    n_module_shared = n_pix_shared + n_sct_shared / 2
+
+    print(n_module_shared[selected["valid"]])
+    assert not np.any(n_module_shared[selected["valid"]] > 1)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add a custom cut for the nshared selection in the track selector

Relates to the following issues

* #3 
* #89 

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
