### PR TITLE
Modifications for s-tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can set up and run pre-commit hooks with
 
 ```bash
 pre-commit install
-pre-commmit run --all-files
+pre-commit run --all-files
 ```
 
 To run the tests you can use the `pytest` or `coverage` command, for example

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -19,6 +19,22 @@
   cuts: ["HadronConeExclTruthLabelID == 15"]
   colour: tab:purple
   category: single-btag
+# The `ujets` class defined above is further split into these three classes
+- name: gjets
+  label: Gluon-jets
+  cuts: ["HadronConeExclTruthLabelID == 0", "PartonTruthLabelID == 21"]
+  colour: tab:yellow
+  category: single-btag
+- name: udjets
+  label: Light-quark-jets
+  cuts: ["HadronConeExclTruthLabelID == 0", "PartonTruthLabelID <= 2"]
+  colour: tab:olive
+  category: single-btag
+- name: sjets
+  label: $s$-jets
+  cuts: ["HadronConeExclTruthLabelID == 0", "PartonTruthLabelID == 3"]
+  colour: tab:red
+  category: single-btag
 
 # extended single b-tagging
 - name: singlebjets
@@ -67,6 +83,22 @@
   label: $\tau$-jets
   cuts: ["HadronGhostTruthLabelID == 15"]
   colour: tab:purple
+  category: single-btag-ghost
+# The `ghostujets` class defined above is further split into these three classes
+- name: ghostgjets
+  label: Gluon-jets
+  cuts: ["HadronGhostTruthLabelID == 0", "PartonTruthLabelID == 21"]
+  colour: tab:yellow
+  category: single-btag-ghost
+- name: ghostudjets
+  label: Light-quark-jets
+  cuts: ["HadronGhostTruthLabelID == 0", "PartonTruthLabelID <= 2"]
+  colour: tab:olive
+  category: single-btag-ghost
+- name: ghostsjets
+  label: $s$-jets
+  cuts: ["HadronGhostTruthLabelID == 0", "PartonTruthLabelID == 3"]
+  colour: tab:red
   category: single-btag-ghost
 
 # Xbb tagging


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Splits Light-jets into Gluon-jets, Light-quark-jets and s-jets, for both single-btag and single-btag-ghost classes.
* Fixes a minor typo in README.

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
