### PR TITLE
Added temporary discriminant for ghost labelled jets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Added temporary discriminant for ghost jets [#99](https://github.com/umami-hep/atlas-ftag-tools/pull/99)
 - Bugfix for track_selector [#98](https://github.com/umami-hep/atlas-ftag-tools/pull/98)
 
 ### [v0.2.5]

--- a/ftag/tests/wps/test_discriminant.py
+++ b/ftag/tests/wps/test_discriminant.py
@@ -8,6 +8,7 @@ from ftag.wps.discriminant import (
     btag_discriminant,
     ctag_discriminant,
     get_discriminant,
+    ghostbtag_discriminant,
     hbb_discriminant,
     hcc_discriminant,
     tautag_dicriminant,
@@ -77,6 +78,24 @@ def test_no_tau_with_ftau():
         btag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
     with pytest.raises(ValueError):
         ctag_discriminant(jets, tagger, fc, ftau, epsilon=epsilon)
+
+
+def test_ghostbtag_discriminant():
+    jets = np.array(
+        [
+            (0.2, 0.3, 0.9),
+            (0.8, 0.5, 0.1),
+            (0.6, 0.1, 0.7),
+        ],
+        dtype=[("tagger_pghostb", "f4"), ("tagger_pghostc", "f4"), ("tagger_pghostu", "f4")],
+    )
+    tagger = "tagger"
+    fc = 0.1
+    epsilon = 1e-10
+    disc = ghostbtag_discriminant(jets, tagger, fc, epsilon=epsilon)
+    pb, pc, pu = jets[f"{tagger}_pghostb"], jets[f"{tagger}_pghostc"], jets[f"{tagger}_pghostu"]
+    expected = np.log((pb + epsilon) / ((1.0 - fc) * pu + fc * pc + epsilon))
+    assert np.allclose(disc, expected)
 
 
 def test_ctag_discriminant():
@@ -200,6 +219,21 @@ def test_get_discriminant():
     signal = Flavours.cjets
     disc = get_discriminant(jets, tagger, signal, fb=0.2)
     expected = ctag_discriminant(jets, tagger, fb=0.2)
+    assert np.allclose(disc, expected)
+
+    jets = np.array(
+        [
+            (0.2, 0.3, 0.5),
+            (0.8, 0.5, 0.1),
+            (0.6, 0.1, 0.7),
+        ],
+        dtype=[("tagger_pghostb", "f4"), ("tagger_pghostc", "f4"), ("tagger_pghostu", "f4")],
+    )
+
+    tagger = "tagger"
+    signal = Flavours.ghostbjets
+    disc = get_discriminant(jets, tagger, signal, fc=0.1)
+    expected = ghostbtag_discriminant(jets, tagger, fc=0.1)
     assert np.allclose(disc, expected)
 
     jets = np.array(

--- a/ftag/wps/discriminant.py
+++ b/ftag/wps/discriminant.py
@@ -63,6 +63,11 @@ def btag_discriminant(jets, tagger, fc, ftau=0, epsilon=1e-10):
     return discriminant(jets, tagger, Flavours.bjets, fxs, epsilon=epsilon)
 
 
+def ghostbtag_discriminant(jets, tagger, fc, ftau=0, epsilon=1e-10):
+    fxs = {"pghostc": fc, "pghosttau": ftau, "pghostu": 1 - fc - ftau}
+    return discriminant(jets, tagger, Flavours.ghostbjets, fxs, epsilon=epsilon)
+
+
 def ctag_discriminant(jets, tagger, fb, ftau=0, epsilon=1e-10):
     fxs = {"pb": fb, "ptau": ftau, "pu": 1 - fb - ftau}
     return discriminant(jets, tagger, Flavours.cjets, fxs, epsilon=epsilon)
@@ -112,6 +117,7 @@ def get_discriminant(
         "taujets": tautag_dicriminant,
         "hbb": hbb_discriminant,
         "hcc": hcc_discriminant,
+        "ghostbjets": ghostbtag_discriminant,
     }
 
     if str(signal) not in tagger_funcs:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* 
*

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
