### PR TITLE
Labeller integration to salt

### DIFF
--- a/ftag/__init__.py
+++ b/ftag/__init__.py
@@ -8,6 +8,7 @@ __version__ = "v0.2.5"
 from ftag import hdf5
 from ftag.cuts import Cuts
 from ftag.flavour import Flavour, Flavours
+from ftag.labeller import Labeller
 from ftag.mock import get_mock_file
 from ftag.sample import Sample
 from ftag.transform import Transform
@@ -18,6 +19,7 @@ __all__ = [
     "Cuts",
     "Flavour",
     "Flavours",
+    "Labeller",
     "Sample",
     "Transform",
     "__version__",

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -94,6 +94,31 @@
   cuts: ["R10TruthLabel_R22v1 == 10"]
   colour: "#38761D"
   category: xbb
+- name: qcdbb
+  label: QCD->bb
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 2"]
+  colour: "red"
+  category: xbb
+- name: qcdnonbb
+  label: QCD
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount != 2"]
+  colour: "silver"
+  category: xbb
+- name: qcdbl
+  label: QCD
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 1"]
+  colour: "gold"
+  category: xbb
+- name: qcdcl
+  label: QCD
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostCHadronsFinalCount >= 1", "GhostBHadronsFinalCount == 0"]
+  colour: "pink"
+  category: xbb
+- name: qcdll
+  label: QCD
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 0", "GhostCHadronsFinalCount == 0"]
+  colour: "green"
+  category: xbb
 
 # extended Xbb tagging
 - name: tqqb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -104,12 +104,12 @@
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount != 2"]
   colour: "silver"
   category: xbb
-- name: qcdbl
+- name: qcdbx
   label: QCD
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 1"]
   colour: "gold"
   category: xbb
-- name: qcdcl
+- name: qcdcx
   label: QCD
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostCHadronsFinalCount >= 1", "GhostBHadronsFinalCount == 0"]
   colour: "pink"

--- a/ftag/labeller.py
+++ b/ftag/labeller.py
@@ -27,6 +27,10 @@ class Labeller:
     labels: FlavourContainer | list[str | Flavour]
     require_labels: bool = True
 
+    @property
+    def variables(self):
+        return sum((label.cuts.variables for label in self.labels), [])
+
     def __post_init__(self) -> None:
         if isinstance(self.labels, FlavourContainer):
             self.labels = list(self.labels)

--- a/ftag/labeller.py
+++ b/ftag/labeller.py
@@ -4,8 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from ftag import Flavours
-from ftag.flavour import Flavour, FlavourContainer
+from ftag.flavour import Flavour, FlavourContainer, Flavours
 from ftag.hdf5 import join_structured_arrays, structured_from_dict
 
 

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -23,6 +23,7 @@ JET_VARS = [
     ("HadronConeExclTruthLabelPt", "f4"),
     ("R10TruthLabel_R22v1", "i4"),
     ("GhostBHadronsFinalCount", "i4"),
+    ("GhostCHadronsFinalCount", "i4"),
     ("n_truth_promptLepton", "i4"),
     ("flavour_label", "i4"),
 ]
@@ -100,6 +101,8 @@ def mock_jets(num_jets=1000) -> np.ndarray:
 
     # add tagger scores
     jets["HadronConeExclTruthLabelID"] = rng.choice([0, 4, 5, 15], size=num_jets)
+    jets["GhostBHadronsFinalCount"] = rng.choice([0, 1, 2], size=num_jets)
+    jets["GhostCHadronsFinalCount"] = rng.choice([0, 1, 2], size=num_jets)
     jets["R10TruthLabel_R22v1"] = rng.choice([1, 10, 11, 12], size=num_jets)
     scores = get_mock_scores(jets["HadronConeExclTruthLabelID"])
     xbb_scores = get_mock_scores(jets["R10TruthLabel_R22v1"], is_xbb=True)

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -22,6 +22,7 @@ JET_VARS = [
     ("HadronConeExclTruthLabelID", "i4"),
     ("HadronConeExclTruthLabelPt", "f4"),
     ("R10TruthLabel_R22v1", "i4"),
+    ("GhostBHadronsFinalCount", "i4"),
     ("n_truth_promptLepton", "i4"),
     ("flavour_label", "i4"),
 ]

--- a/ftag/tests/test_labeller.py
+++ b/ftag/tests/test_labeller.py
@@ -67,13 +67,13 @@ def test_add_labels(jets):
     with pytest.raises(ValueError, match="Cannot add labels if require_labels is set to False"):
         labeller.add_labels(jets)
 
-def test_labeller_property(jets):
+def test_labeller_property():
     flavours = ["bjets", "cjets"]
     labeller = Labeller(flavours)
-    vars = labeller.variables
-    assert(vars == ["HadronConeExclTruthLabelID", "HadronConeExclTruthLabelID"])
+    label_vars = labeller.variables
+    assert(label_vars == ["HadronConeExclTruthLabelID", "HadronConeExclTruthLabelID"])
 
     flavours = ["qcdbb"]
     labeller = Labeller(flavours)
-    vars = labeller.variables
-    assert(vars == ["R10TruthLabel_R22v1", "GhostBHadronsFinalCount"])
+    label_vars = labeller.variables
+    assert(label_vars == ["R10TruthLabel_R22v1", "GhostBHadronsFinalCount"])

--- a/ftag/tests/test_labeller.py
+++ b/ftag/tests/test_labeller.py
@@ -67,6 +67,7 @@ def test_add_labels(jets):
     with pytest.raises(ValueError, match="Cannot add labels if require_labels is set to False"):
         labeller.add_labels(jets)
 
+
 def test_labeller_property():
     flavours = ["bjets", "cjets"]
     labeller = Labeller(flavours)

--- a/ftag/tests/test_labeller.py
+++ b/ftag/tests/test_labeller.py
@@ -66,3 +66,14 @@ def test_add_labels(jets):
     labeller = Labeller(flavours, require_labels=False)
     with pytest.raises(ValueError, match="Cannot add labels if require_labels is set to False"):
         labeller.add_labels(jets)
+
+def test_labeller_property(jets):
+    flavours = ["bjets", "cjets"]
+    labeller = Labeller(flavours)
+    vars = labeller.variables
+    assert(vars == ["HadronConeExclTruthLabelID", "HadronConeExclTruthLabelID"])
+
+    flavours = ["qcdbb"]
+    labeller = Labeller(flavours)
+    vars = labeller.variables
+    assert(vars == ["R10TruthLabel_R22v1", "GhostBHadronsFinalCount"])

--- a/ftag/tests/test_labeller.py
+++ b/ftag/tests/test_labeller.py
@@ -71,9 +71,9 @@ def test_labeller_property():
     flavours = ["bjets", "cjets"]
     labeller = Labeller(flavours)
     label_vars = labeller.variables
-    assert(label_vars == ["HadronConeExclTruthLabelID", "HadronConeExclTruthLabelID"])
+    assert label_vars == ["HadronConeExclTruthLabelID", "HadronConeExclTruthLabelID"]
 
     flavours = ["qcdbb"]
     labeller = Labeller(flavours)
     label_vars = labeller.variables
-    assert(label_vars == ["R10TruthLabel_R22v1", "GhostBHadronsFinalCount"])
+    assert label_vars == ["R10TruthLabel_R22v1", "GhostBHadronsFinalCount"]

--- a/ftag/tests/wps/test_working_points.py
+++ b/ftag/tests/wps/test_working_points.py
@@ -11,8 +11,7 @@ from ftag.wps.working_points import main
 
 @pytest.fixture
 def test_file():
-    mock = get_mock_file(10_000)[0]
-    return mock
+    return get_mock_file(10_000)[0]
 
 
 @pytest.fixture

--- a/ftag/tests/wps/test_working_points.py
+++ b/ftag/tests/wps/test_working_points.py
@@ -11,7 +11,8 @@ from ftag.wps.working_points import main
 
 @pytest.fixture
 def test_file():
-    return get_mock_file(10_000)[0]
+    mock = get_mock_file(10_000)[0]
+    return mock
 
 
 @pytest.fixture

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -219,10 +219,6 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    #var_ls = []
-    #for flav in flavs:
-    #    var_ls.append(flav.cuts.variables)
-
     var_ls = [flav.cuts.variables for flav in flavs]
     all_vars = list(set(chain(*var_ls)))
     reader = H5Reader(args.ttbar)

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -222,7 +222,6 @@ def setup_common_parts(args):
     var_ls = []
     for flav in flavs:
         var_ls.append(flav.cuts.variables)
-        var_ls
 
     all_vars = list(set(chain(*var_ls)))
     reader = H5Reader(args.ttbar)

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -218,8 +218,8 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    vars_ls = [flav.cuts.variables for flav in flavs]
-    all_vars = list(set(sum(vars_ls, [])))
+    #vars_ls = [flav.cuts.variables for flav in flavs]
+    all_vars = list(set(sum((flav.cuts.variables for flav in flavs), [])))
     reader = H5Reader(args.ttbar)
     jet_vars = reader.dtypes()["jets"].names
     for tagger in args.tagger:

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -219,10 +219,11 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    var_ls = []
-    for flav in flavs:
-        var_ls.append(flav.cuts.variables)
+    #var_ls = []
+    #for flav in flavs:
+    #    var_ls.append(flav.cuts.variables)
 
+    var_ls = [flav.cuts.variables for flav in flavs]
     all_vars = list(set(chain(*var_ls)))
     reader = H5Reader(args.ttbar)
     jet_vars = reader.dtypes()["jets"].names

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import argparse
+from itertools import chain
 from pathlib import Path
 
 import numpy as np
 import yaml
-from itertools import chain
 
 from ftag.cli_utils import HelpFormatter
 from ftag.cuts import Cuts

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -218,7 +218,6 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    #vars_ls = [flav.cuts.variables for flav in flavs]
     all_vars = list(set(sum((flav.cuts.variables for flav in flavs), [])))
     reader = H5Reader(args.ttbar)
     jet_vars = reader.dtypes()["jets"].names

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-from itertools import chain
 from pathlib import Path
 
 import numpy as np
@@ -219,8 +218,7 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    var_ls = [flav.cuts.variables for flav in flavs]
-    all_vars = list(set(chain(*var_ls)))
+    all_vars = list(set(sum([flav.cuts.variables for flav in flavs], [])))
     reader = H5Reader(args.ttbar)
     jet_vars = reader.dtypes()["jets"].names
     for tagger in args.tagger:

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -218,7 +218,8 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    all_vars = list(set(sum([flav.cuts.variables for flav in flavs], [])))
+    vars_ls = [flav.cuts.variables for flav in flavs]
+    all_vars = list(set(sum(vars_ls, [])))
     reader = H5Reader(args.ttbar)
     jet_vars = reader.dtypes()["jets"].names
     for tagger in args.tagger:

--- a/ftag/wps/working_points.py
+++ b/ftag/wps/working_points.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import numpy as np
 import yaml
+from itertools import chain
 
 from ftag.cli_utils import HelpFormatter
 from ftag.cuts import Cuts
@@ -218,7 +219,12 @@ def setup_common_parts(args):
     zprime_cuts = Cuts.from_list(args.zprime_cuts) + default_cuts
 
     # prepare to load jets
-    all_vars = next(iter(flavs)).cuts.variables
+    var_ls = []
+    for flav in flavs:
+        var_ls.append(flav.cuts.variables)
+        var_ls
+
+    all_vars = list(set(chain(*var_ls)))
     reader = H5Reader(args.ttbar)
     jet_vars = reader.dtypes()["jets"].names
     for tagger in args.tagger:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* New classes in flavour file to split qcd in subclasses
* Addition to labeller for salt integration
* Related tests

Relates to the following issues

* Labelling on-the-fly
* QCD splitting

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
