### PR TITLE
Add weights attribute to Sample class

### DIFF
--- a/ftag/sample.py
+++ b/ftag/sample.py
@@ -13,6 +13,7 @@ class Sample:
     pattern: Path | str | tuple[Path | str, ...]
     ntuple_dir: Path | str | None = None
     name: str | None = None
+    weights: list[float] | None = None
 
     def __post_init__(self) -> None:
         if not self.pattern:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Add weights attribute to Sample class

Relates to the following issues
* Weights provided in the upp config is not passed to the H5Reader

Tagging @samvanstroud 

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
