### PR TITLE
Update flavours.yaml

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Update isolation flavour labels [106] (https://github.com/umami-hep/atlas-ftag-tools/pull/106)
+
 ### [v0.2.7]
 - Add weights to sample class [#104](https://github.com/umami-hep/atlas-ftag-tools/pull/104)
 - Rename flavours to labels [#103](https://github.com/umami-hep/atlas-ftag-tools/pull/103)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Update isolation flavour labels [106] (https://github.com/umami-hep/atlas-ftag-tools/pull/106)
+- Update isolation flavour labels [106](https://github.com/umami-hep/atlas-ftag-tools/pull/106)
 
 ### [v0.2.7]
 - Add weights to sample class [#104](https://github.com/umami-hep/atlas-ftag-tools/pull/104)

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -272,7 +272,7 @@
   category: isolation
 - name: npxall
   label: non-prompt lepton
-  cuts: ["iffClass notin (2,3,4,11)"]
+  cuts: ["iffClass notin (0,1,2,3,4,11)"]
   colour: "#264653"
   category: isolation
 - name: npxtau


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update contains the new definition of the non-prompt category for muons and electrons. It was decided not to train or evaluate isolation algorithms on IFF classes 0 and 1.

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
