### PR TITLE
Adding label for GN2XTau

### DIFF
--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -131,17 +131,17 @@
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 0", "GhostCHadronsFinalCount == 0"]
   colour: "green"
   category: xbb
-- name: htautauel
-  label: $H \rightarrow e\tau$
+- name: htauel
+  label: $H \rightarrow \tau e$
   cuts: ["R10TruthLabel_R22v1 == 14"]
   colour: "#b40612"
   category: xbb
-- name: htautaumu
-  label: $H \rightarrow \mu\tau$
+- name: htaumu
+  label: $H \rightarrow \tau\mu$
   cuts: ["R10TruthLabel_R22v1 == 15"]
   colour: "#b40657"
   category: xbb
-- name: htautauhad
+- name: htauhad
   label: $H \rightarrow \tau\tau$
   cuts: ["R10TruthLabel_R22v1 == 16"]
   colour: "#b406a0"

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -131,6 +131,21 @@
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 0", "GhostCHadronsFinalCount == 0"]
   colour: "green"
   category: xbb
+- name: htautauel
+  label: $H \rightarrow e\tau$
+  cuts: ["R10TruthLabel_R22v1 == 14"]
+  colour: "#b40612"
+  category: xbb
+- name: htautaumu
+  label: $H \rightarrow \mu\tau$
+  cuts: ["R10TruthLabel_R22v1 == 15"]
+  colour: "#b40657"
+  category: xbb
+- name: htautauhad
+  label: $H \rightarrow \tau\tau$
+  cuts: ["R10TruthLabel_R22v1 == 16"]
+  colour: "#b406a0"
+  category: xbb
 
 # extended Xbb tagging
 - name: tqqb


### PR DESCRIPTION
## Summary

This follows-up the discussion on the review of the [PubNote](https://cds.cern.ch/record/2925002) for GN2XTau.

This pull request introduces the following change

* Added flavor labels for H->tauel, H->taumu, H->tauhad for GN2XTau. What is used in the PubNote so far is only H->tauhad.
