### PR TITLE
Added helper script for adding new columns to an h5 file

### DIFF
--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -682,7 +682,9 @@
     "    # Check if the new column was added\n",
     "    with h5py.File(output, \"r\") as f:\n",
     "        # Should be True\n",
-    "        print(\"Output has 'number_of_tracks'? \", \"number_of_tracks\" in dummy_file[\"jets\"].dtype.names)"
+    "        print(\n",
+    "            \"Output has 'number_of_tracks'? \", \"number_of_tracks\" in dummy_file[\"jets\"].dtype.names\n",
+    "        )"
    ]
   },
   {
@@ -697,13 +699,6 @@
     "\n",
     "Which will then `a_function1` from `/a/path/to/a/python/script.py` and  `a_function2` from `/a/differentpath/to/a/python/script.py`"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -524,16 +524,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ftag.hdf5 import h5_add_column\n",
     "import tempfile\n",
     "\n",
+    "from ftag.hdf5 import h5_add_column\n",
+    "\n",
+    "\n",
     "def add_number_of_tracks(batch):\n",
-    "    num_tracks = batch['tracks']['valid'].sum(axis=1)\n",
+    "    num_tracks = batch[\"tracks\"][\"valid\"].sum(axis=1)\n",
     "    return {\n",
-    "        \"jets\" : { # Add to the 'jets' group\n",
-    "            \"number_of_tracks\": num_tracks, # ... a new variable called 'number_of_tracks'\n",
+    "        \"jets\": {  # Add to the 'jets' group\n",
+    "            \"number_of_tracks\": num_tracks,  # ... a new variable called 'number_of_tracks'\n",
     "        }\n",
     "    }\n",
+    "\n",
     "\n",
     "dummy_file = h5py.File(fname, \"r\")\n",
     "# Should be False\n",
@@ -551,9 +554,7 @@
     "    # Check if the new column was added\n",
     "    with h5py.File(output, \"r\") as f:\n",
     "        # Should be True\n",
-    "        print(\"number_of_tracks\" in f[\"jets\"].dtype.names)\n",
-    "\n",
-    "\n"
+    "        print(\"number_of_tracks\" in f[\"jets\"].dtype.names)"
    ]
   }
  ],

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,9 +150,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Label(name='bjets', label='$b$-jets', cuts=['HadronConeExclTruthLabelID == 5'], colour='tab:blue', category='single-btag', _px=None)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from ftag import Flavours\n",
     "\n",
@@ -169,9 +180,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Label(name='qcd', label='QCD', cuts=['R10TruthLabel_R22v1 == 10'], colour='#38761D', category='xbb', _px=None)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Flavours[\"qcd\"]"
    ]
@@ -187,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,18 +226,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['single-btag',\n",
+       " 'single-btag-extended',\n",
+       " 'single-btag-ghost',\n",
+       " 'xbb',\n",
+       " 'xbb-extended',\n",
+       " 'partonic',\n",
+       " 'lepton-decay',\n",
+       " 'PDGID',\n",
+       " 'isolation',\n",
+       " 'trigger-xbb']"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Flavours.categories"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "LabelContainer(hbb, hcc, top, qcd, qcdbb, qcdnonbb, qcdbx, qcdcx, qcdll, htauel, htaumu, htauhad)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Flavours.by_category(\"xbb\")"
    ]
@@ -230,9 +283,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['pb', 'pc', 'pu', 'ptau']"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "[f.px for f in Flavours.by_category(\"single-btag\")]"
    ]
@@ -247,9 +311,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Label(name='bjets', label='$b$-jets', cuts=['HadronConeExclTruthLabelID == 5'], colour='tab:blue', category='single-btag', _px=None)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Flavours.from_cuts([\"HadronConeExclTruthLabelID == 5\"])"
    ]
@@ -272,9 +347,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "300"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from ftag.hdf5 import H5Reader\n",
     "\n",
@@ -295,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,9 +400,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1000"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "reader.num_jets"
    ]
@@ -331,9 +428,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dtype([('dphi', '<f4'), ('deta', '<f4')])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "data = reader.load({\"jets\": [\"pt\", \"eta\"], \"tracks\": [\"deta\", \"dphi\"]}, num_jets=100)\n",
     "data[\"tracks\"].dtype"
@@ -349,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +505,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,9 +607,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(np.float32(8.156475), np.float32(12.896797))"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "reader = H5Reader(fname, batch_size=100, transform=transform)\n",
     "data = reader.load({\"jets\": [\"pt\", \"eta\"]}, num_jets=300)\n",
@@ -520,9 +639,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input has 'number_of_tracks'?  False\n",
+      "Output has 'number_of_tracks'?  False\n"
+     ]
+    }
+   ],
    "source": [
     "import tempfile\n",
     "\n",
@@ -540,7 +668,7 @@
     "\n",
     "dummy_file = h5py.File(fname, \"r\")\n",
     "# Should be False\n",
-    "print(\"number_of_tracks\" in dummy_file[\"jets\"].dtype.names)\n",
+    "print(\"Input has 'number_of_tracks'? \", \"number_of_tracks\" in dummy_file[\"jets\"].dtype.names)\n",
     "\n",
     "# Create a temporary file path for output\n",
     "with tempfile.TemporaryDirectory() as tmpdir:\n",
@@ -554,8 +682,15 @@
     "    # Check if the new column was added\n",
     "    with h5py.File(output, \"r\") as f:\n",
     "        # Should be True\n",
-    "        print(\"number_of_tracks\" in f[\"jets\"].dtype.names)"
+    "        print(\"Output has 'number_of_tracks'? \", \"number_of_tracks\" in dummy_file[\"jets\"].dtype.names)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -686,6 +686,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You ccan also use the above as a script from the terminal\n",
+    "\n",
+    "```bash\n",
+    "h5addcol --input [input file] --append_function /a/path/to/a/python/script.py:a_function1 /a/differentpath/to/a/python/script.py:a_function2\n",
+    "```\n",
+    "\n",
+    "Which will then `a_function1` from `/a/path/to/a/python/script.py` and  `a_function2` from `/a/differentpath/to/a/python/script.py`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/ftag/example.ipynb
+++ b/ftag/example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,20 +150,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Flavour(name='bjets', label='$b$-jets', cuts=['HadronConeExclTruthLabelID == 5'], colour='tab:blue', category='single-btag')"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ftag import Flavours\n",
     "\n",
@@ -180,20 +169,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Flavour(name='qcd', label='QCD', cuts=['R10TruthLabel_R22v1 == 10'], colour='#38761D', category='xbb')"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Flavours[\"qcd\"]"
    ]
@@ -209,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,40 +204,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['single-btag', 'single-btag-extended', 'xbb', 'partonic', 'lepton-decay']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Flavours.categories"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "FlavourContainer(hbb, hcc, top, inclusive_top, qcd)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Flavours.by_category(\"xbb\")"
    ]
@@ -274,20 +230,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['pb', 'pc', 'pu', 'ptau']"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "[f.px for f in Flavours.by_category(\"single-btag\")]"
    ]
@@ -302,20 +247,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Flavour(name='bjets', label='$b$-jets', cuts=['HadronConeExclTruthLabelID == 5'], colour='tab:blue', category='single-btag')"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "Flavours.from_cuts([\"HadronConeExclTruthLabelID == 5\"])"
    ]
@@ -338,20 +272,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "300"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ftag.hdf5 import H5Reader\n",
     "\n",
@@ -372,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,20 +314,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1000"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reader.num_jets"
    ]
@@ -419,20 +331,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dtype([('dphi', '<f4'), ('deta', '<f4')])"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "data = reader.load({\"jets\": [\"pt\", \"eta\"], \"tracks\": [\"deta\", \"dphi\"]}, num_jets=100)\n",
     "data[\"tracks\"].dtype"
@@ -448,7 +349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +425,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,30 +499,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(6.871671, 12.899197)"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "reader = H5Reader(fname, batch_size=100, transform=transform)\n",
     "data = reader.load({\"jets\": [\"pt\", \"eta\"]}, num_jets=300)\n",
     "data[\"jets\"][\"pt\"].min(), data[\"jets\"][\"pt\"].max()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding columns to an h5 file.\n",
+    "\n",
+    "Quite often we wish to make minor changes to h5 files, e.g. adding a single new jet or track variable. A helper function, `h5_add_column` is available to aid here.\n",
+    "The function requires an input file, and output file, and a function (or list of functions) which return a dictionary detailing what needs to be appended. An example is included below"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ftag.hdf5 import h5_add_column\n",
+    "import tempfile\n",
+    "\n",
+    "def add_number_of_tracks(batch):\n",
+    "    num_tracks = batch['tracks']['valid'].sum(axis=1)\n",
+    "    return {\n",
+    "        \"jets\" : { # Add to the 'jets' group\n",
+    "            \"number_of_tracks\": num_tracks, # ... a new variable called 'number_of_tracks'\n",
+    "        }\n",
+    "    }\n",
+    "\n",
+    "dummy_file = h5py.File(fname, \"r\")\n",
+    "# Should be False\n",
+    "print(\"number_of_tracks\" in dummy_file[\"jets\"].dtype.names)\n",
+    "\n",
+    "# Create a temporary file path for output\n",
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    output = Path(tmpdir) / \"output.h5\"\n",
+    "    h5_add_column(\n",
+    "        fname,\n",
+    "        output,\n",
+    "        add_number_of_tracks,\n",
+    "        num_jets=1000,\n",
+    "    )\n",
+    "    # Check if the new column was added\n",
+    "    with h5py.File(output, \"r\") as f:\n",
+    "        # Should be True\n",
+    "        print(\"number_of_tracks\" in f[\"jets\"].dtype.names)\n",
+    "\n",
+    "\n"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "jetpp",
+   "display_name": "atlas-ftag-tools",
    "language": "python",
    "name": "python3"
   },
@@ -635,7 +573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/ftag/hdf5/__init__.py
+++ b/ftag/hdf5/__init__.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+from .h5add_col import h5_add_column
 from .h5reader import H5Reader
 from .h5utils import cast_dtype, get_dtype, join_structured_arrays, structured_from_dict
 from .h5writer import H5Writer
-from .h5add_col import h5_add_column
-__all__ = [
 
+__all__ = [
     "H5Reader",
     "H5Writer",
     "cast_dtype",
     "get_dtype",
+    "h5_add_column",
     "join_structured_arrays",
     "structured_from_dict",
-    "h5_add_column"
 ]

--- a/ftag/hdf5/__init__.py
+++ b/ftag/hdf5/__init__.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from .h5reader import H5Reader
 from .h5utils import cast_dtype, get_dtype, join_structured_arrays, structured_from_dict
 from .h5writer import H5Writer
-
+from .h5add_col import h5_add_column
 __all__ = [
+
     "H5Reader",
     "H5Writer",
     "cast_dtype",
     "get_dtype",
     "join_structured_arrays",
     "structured_from_dict",
+    "h5_add_column"
 ]

--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -11,7 +11,7 @@ from ftag.hdf5.h5reader import H5Reader
 from ftag.hdf5.h5writer import H5Writer
 
 
-def merge_dicts(dicts):
+def merge_dicts(dicts: list[dict[str, dict[str, np.ndarray]]]) -> dict[str, dict[str, np.ndarray]]:
     """Merges a list of dictionaries.
 
     Each dict is of the form:
@@ -88,12 +88,12 @@ def merge_dicts(dicts):
     return merged
 
 
-def get_shape(n, batch):
+def get_shape(num_jets: int, batch: dict[str, np.ndarray]) -> dict[str, tuple[int]]:
     """Returns a dictionary with the correct output shapes for the H5Writer.
 
     Parameters
     ----------
-    N : int
+    num_jets : int
         Number of jets to write in total
     batch : dict[str, np.ndarray]
         Dictionary representing the batch
@@ -107,13 +107,26 @@ def get_shape(n, batch):
 
     for key in batch:
         if batch[key].ndim == 1:
-            shape[key] = (n,)
+            shape[key] = (num_jets,)
         else:
-            shape[key] = (n,) + batch[key].shape[1:]
+            shape[key] = (num_jets,) + batch[key].shape[1:]
     return shape
 
 
-def get_all_groups(file) -> dict[str, None]:
+def get_all_groups(file : Path | str) -> dict[str, None]:
+    """_summary_
+
+    Parameters
+    ----------
+    file : Path | str
+        Path to the h5 file
+
+    Returns
+    -------
+    dict[str, None]
+        A dictionary with all the groups in the h5 file as keys and None as values,
+        such that h5read.stream(all_groups) will return all the groups in the file.
+    """
     with h5py.File(file, "r") as f:
         groups = list(f.keys())
         return dict.fromkeys(groups)
@@ -129,7 +142,7 @@ def h5_add_column(
     reader_kwargs: dict | None = None,
     writer_kwargs: dict | None = None,
     overwrite: bool = False,
-):
+) -> None:
     """Appends one or more columns to one or more groups in an h5 file.
 
     Parameters

--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -168,7 +168,7 @@ def h5_add_column(
         raise FileExistsError(f"Output file {output_file} already exists. Please choose a different name.")
     
     if output_file is None:
-        output_file = input_file.replace(".h5", "_additional.h5")
+        output_file = input_file.with_name(input_file.name.replace(".h5", "_additional.h5"))
 
     if not isinstance(append_function, list):
         append_function = [append_function]

--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -1,14 +1,20 @@
 # Utils to take an input h5 file, and append one or more columns to it
-import numpy as np
-from ftag.hdf5.h5reader import H5Reader
-from ftag.hdf5.h5writer import H5Writer
-import h5py
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Callable
 
+import h5py
+import numpy as np
+
+from ftag.hdf5.h5reader import H5Reader
+from ftag.hdf5.h5writer import H5Writer
+
+
 def merge_dicts(dicts):
-    """
-    Merges a list of dictionaries whre each dict is of the form:
+    """Merges a list of dictionaries.
+
+    Each dict is of the form:
      {
         group1: {
             variable_1: np.array
@@ -63,6 +69,11 @@ def merge_dicts(dicts):
                 variable_2: np.array
             }
         }
+
+    Raises
+    ------
+    ValueError
+        If a variable already exists in the merged dictionary.
     """
     merged = {}
     for d in dicts:
@@ -77,8 +88,8 @@ def merge_dicts(dicts):
     return merged
 
 
-def get_shape(N, batch):
-    """Returns a dictionary with the correct output shapes for the H5Writer
+def get_shape(n, batch):
+    """Returns a dictionary with the correct output shapes for the H5Writer.
 
     Parameters
     ----------
@@ -94,31 +105,31 @@ def get_shape(N, batch):
     """
     shape = {}
 
-    for key in batch.keys():
+    for key in batch:
         if batch[key].ndim == 1:
-            shape[key] = (N,)
+            shape[key] = (n,)
         else:
-            shape[key] = (N,) + batch[key].shape[1:]
+            shape[key] = (n,) + batch[key].shape[1:]
     return shape
 
-def get_all_groups(file):
-    """Returns a dictionary with all groups in the h5 file"""   
+
+def get_all_groups(file) -> dict[str, None]:
     with h5py.File(file, "r") as f:
         groups = list(f.keys())
-        return { g : None for g in groups}
-    
+        return dict.fromkeys(groups)
+
 
 def h5_add_column(
-    input_file : str | Path, 
-    output_file : str | Path, 
-    append_function : Callable | list[Callable], 
-    num_jets : int = -1 ,
-    input_groups : list[str] | None = None,
-    output_groups : list[str] | None = None,
-    reader_kwargs : dict = {},
-    writer_kwargs : dict = {},
-    overwrite : bool = False,
-    ):
+    input_file: str | Path,
+    output_file: str | Path,
+    append_function: Callable | list[Callable],
+    num_jets: int = -1,
+    input_groups: list[str] | None = None,
+    output_groups: list[str] | None = None,
+    reader_kwargs: dict | None = None,
+    writer_kwargs: dict | None = None,
+    overwrite: bool = False,
+):
     """Appends one or more columns to one or more groups in an h5 file.
 
     Parameters
@@ -128,7 +139,7 @@ def h5_add_column(
     output_file : str | Path
         Output h5 file to write to.
     append_function : callable | list[callable]
-        A function, or list of functions, which take a batch from H5Reader and returns a dictionary 
+        A function, or list of functions, which take a batch from H5Reader and returns a dictionary
         of the form:
             {
                 group1 : {
@@ -147,61 +158,83 @@ def h5_add_column(
         List of groups to read from the input file. If None, reads all groups. By default None.
     output_groups : list[str] | None, optional
         List of groups to write to the output file. If None, writes all groups. By default None.
-        Note that this is a subset of the input groups, and must include all groups that the append fucntions
-        wish to write to.
+        Note that this is a subset of the input groups, and must include all groups that the
+        append functions wish to write to.
     reader_kwargs : dict, optional
-        Additional arguments to pass to the H5Reader. By default {}.
+        Additional arguments to pass to the H5Reader. By default None.
     writer_kwargs : dict, optional
-        Additional arguments to pass to the H5Writer. By default {}.
+        Additional arguments to pass to the H5Writer. By default None.
     overwrite : bool, optional
         If True, will overwrite the output file if it exists. By default False.
         If False, will raise a FileExistsError if the output file exists.
-        If None, will check if the output file exists and raise an error if it does unless overwrite is True.
+        If None, will check if the output file exists and raise an error if it does unless
+        overwrite is True.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input file does not exist.
+    FileExistsError
+        If the output file exists and overwrite is False.
+    ValueError
+        If the new variable already exists, shape is incorrect, or the output group is not in
+        the input groups.
+
     """
-    
     input_file = Path(input_file)
     output_file = Path(output_file) if output_file is not None else None
 
     if not input_file.exists():
         raise FileNotFoundError(f"Input file {input_file} does not exist.")
     if output_file is not None and output_file.exists() and not overwrite:
-        raise FileExistsError(f"Output file {output_file} already exists. Please choose a different name.")
-    
+        raise FileExistsError(
+            f"Output file {output_file} already exists. Please choose a different name."
+        )
+    if not reader_kwargs:
+        reader_kwargs = {}
+    if not writer_kwargs:
+        writer_kwargs = {}
     if output_file is None:
         output_file = input_file.with_name(input_file.name.replace(".h5", "_additional.h5"))
 
     if not isinstance(append_function, list):
         append_function = [append_function]
-    
+
     reader = H5Reader(input_file, shuffle=False, **reader_kwargs)
-    if 'precision' not in writer_kwargs:
-        writer_kwargs['precision'] = 'full'
-    
+    if "precision" not in writer_kwargs:
+        writer_kwargs["precision"] = "full"
+
     njets = reader.num_jets if num_jets == -1 else num_jets
     writer = None
 
-    input_groups = get_all_groups(input_file) if input_groups is None else {k : None for k in input_groups}
-    output_groups = list(input_groups.keys()) if output_groups is None else output_groups
-    
-    assert all([o in input_groups for o in output_groups]), f"Output groups {output_groups} not in input groups {input_groups.keys()}"
+    input_variables = (
+        get_all_groups(input_file) if input_groups is None else dict.fromkeys(input_groups)
+    )
+    if output_groups is None:
+        output_groups = list(input_variables.keys())
 
+    assert all(
+        o in input_variables for o in output_groups
+    ), f"Output groups {output_groups} not in input groups {input_variables.keys()}"
 
     num_batches = njets // reader.batch_size + 1
-    for i, batch in enumerate(reader.stream(input_groups, num_jets=njets)):
-        if (i+1) % 10 == 0:
-            print(f"Processing batch {i+1}/{num_batches} ({(i+1)/num_batches*100:.2f}%)")
+    for i, batch in enumerate(reader.stream(input_variables, num_jets=njets)):
+        if (i + 1) % 10 == 0:
+            print(f"Processing batch {i + 1}/{num_batches} ({(i + 1) / num_batches * 100:.2f}%)")
 
-        to_append = merge_dicts(
-            [af(batch) for af in append_function]
-        )
+        to_append = merge_dicts([af(batch) for af in append_function])
         for k, newvars in to_append.items():
             if k not in output_groups:
                 raise ValueError(f"Trying to output to {k} but only {output_groups} are allowed")
             for newkey, newval in newvars.items():
                 if newkey in batch[k].dtype.names:
-                    raise ValueError(f"Trying to append {newkey} to {k} but it already exists in batch") 
+                    raise ValueError(
+                        f"Trying to append {newkey} to {k} but it already exists in batch"
+                    )
                 if newval.shape != batch[k].shape:
-                    raise ValueError(f"Trying to append {newkey} to {k} but the shape is not correct")
+                    raise ValueError(
+                        f"Trying to append {newkey} to {k} but the shape is not correct"
+                    )
 
         to_write = {}
 
@@ -209,14 +242,15 @@ def h5_add_column(
             if key not in output_groups:
                 continue
             if key in to_append:
-                
-                str_array = np.lib.recfunctions.append_fields(
+                combined = np.lib.recfunctions.append_fields(
                     str_array,
                     list(to_append[key].keys()),
                     list(to_append[key].values()),
                     usemask=False,
                 )
-            to_write[key] = str_array
+                to_write[key] = combined
+            else:
+                to_write[key] = str_array
         if writer is None:
             writer = H5Writer(
                 output_file,
@@ -225,6 +259,5 @@ def h5_add_column(
                 shuffle=False,
                 **writer_kwargs,
             )
-        
+
         writer.write(to_write)
-                

--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -1,0 +1,230 @@
+# Utils to take an input h5 file, and append one or more columns to it
+import numpy as np
+from ftag.hdf5.h5reader import H5Reader
+from ftag.hdf5.h5writer import H5Writer
+import h5py
+from tqdm import tqdm
+from pathlib import Path
+from typing import Callable
+def merge_dicts(dicts):
+    """
+    Merges a list of dictionaries whre each dict is of the form:
+     {
+        group1: {
+            variable_1: np.array
+            variable_2: np.array
+        },
+        group2: {
+            variable_1: np.array
+            variable_2: np.array
+        }
+     }
+
+     E.g.
+
+     dict1 = {
+        "jets": {
+            "pt": np.array([1, 2, 3]),
+            "eta": np.array([4, 5, 6])
+        },
+    }
+    dict2 = {
+        "jets": {
+            "phi": np.array([7, 8, 9]),
+            "energy": np.array([10, 11, 12])
+        },
+    }
+
+    merged = {
+        "jets": {
+            "pt": np.array([1, 2, 3]),
+            "eta": np.array([4, 5, 6]),
+            "phi": np.array([7, 8, 9]),
+            "energy": np.array([10, 11, 12])
+        }
+    }
+
+    Parameters
+    ----------
+    dicts : list[dict[str, dict[str, np.ndarray]]]
+        List of dictionaries to merge. Each dictionary should be of the form:
+
+    Returns
+    -------
+    dict[str, dict[str, np.ndarray]]
+        Merged dictionary of the form:
+        {
+            group1: {
+                variable_1: np.array
+                variable_2: np.array
+            },
+            group2: {
+                variable_1: np.array
+                variable_2: np.array
+            }
+        }
+    """
+    merged = {}
+    for d in dicts:
+        for group, variables in d.items():
+            if group not in merged:
+                merged[group] = {}
+            for variable, data in variables.items():
+                if variable not in merged[group]:
+                    merged[group][variable] = data
+                else:
+                    raise ValueError(f"Variable {variable} already exists in group {group}.")
+    return merged
+
+
+def get_shape(N, batch):
+    """Returns a dictionary with the correct output shapes for the H5Writer
+
+    Parameters
+    ----------
+    N : int
+        Number of jets to write in total
+    batch : dict[str, np.ndarray]
+        Dictionary representing the batch
+
+    Returns
+    -------
+    dict[str, tuple[int]]
+        Dictionary with the shapes of the output arrays
+    """
+    shape = {}
+
+    for key in batch.keys():
+        if batch[key].ndim == 1:
+            shape[key] = (N,)
+        else:
+            shape[key] = (N,) + batch[key].shape[1:]
+    return shape
+
+def get_all_groups(file):
+    """Returns a dictionary with all groups in the h5 file"""   
+    with h5py.File(file, "r") as f:
+        groups = list(f.keys())
+        return { g : None for g in groups}
+    
+
+def h5_add_column(
+    input_file : str | Path, 
+    output_file : str | Path, 
+    append_function : Callable | list[Callable], 
+    num_jets : int = -1 ,
+    input_groups : list[str] | None = None,
+    output_groups : list[str] | None = None,
+    reader_kwargs : dict = {},
+    writer_kwargs : dict = {},
+    overwrite : bool = False,
+    ):
+    """Appends one or more columns to one or more groups in an h5 file.
+
+    Parameters
+    ----------
+    input_file : str | Path
+        Input h5 file to read from.
+    output_file : str | Path
+        Output h5 file to write to.
+    append_function : callable | list[callable]
+        A function, or list of functions, which take a batch from H5Reader and returns a dictionary 
+        of the form:
+            {
+                group1 : {
+                    new_column1 : data,
+                    new_column2 : data,
+                },
+                group2 : {
+                    new_column3 : data,
+                    new_column4 : data,
+                },
+                ...
+            }
+    num_jets : int, optional
+        Number of jets to read from the input file. If -1, reads all jets. By default -1.
+    input_groups : list[str] | None, optional
+        List of groups to read from the input file. If None, reads all groups. By default None.
+    output_groups : list[str] | None, optional
+        List of groups to write to the output file. If None, writes all groups. By default None.
+        Note that this is a subset of the input groups, and must include all groups that the append fucntions
+        wish to write to.
+    reader_kwargs : dict, optional
+        Additional arguments to pass to the H5Reader. By default {}.
+    writer_kwargs : dict, optional
+        Additional arguments to pass to the H5Writer. By default {}.
+    overwrite : bool, optional
+        If True, will overwrite the output file if it exists. By default False.
+        If False, will raise a FileExistsError if the output file exists.
+        If None, will check if the output file exists and raise an error if it does unless overwrite is True.
+    """
+    
+    input_file = Path(input_file)
+    output_file = Path(output_file) if output_file is not None else None
+
+    if not input_file.exists():
+        raise FileNotFoundError(f"Input file {input_file} does not exist.")
+    if output_file is not None and output_file.exists() and not overwrite:
+        raise FileExistsError(f"Output file {output_file} already exists. Please choose a different name.")
+    
+    if output_file is None:
+        output_file = input_file.replace(".h5", "_additional.h5")
+
+    if not isinstance(append_function, list):
+        append_function = [append_function]
+    
+    reader = H5Reader(input_file, shuffle=False, **reader_kwargs)
+    if 'precision' not in writer_kwargs:
+        writer_kwargs['precision'] = 'full'
+    
+    njets = reader.num_jets if num_jets == -1 else num_jets
+    writer = None
+
+    input_groups = get_all_groups(input_file) if input_groups is None else {k : None for k in input_groups}
+    output_groups = list(input_groups.keys()) if output_groups is None else output_groups
+    
+    assert all([o in input_groups for o in output_groups]), f"Output groups {output_groups} not in input groups {input_groups.keys()}"
+
+
+    num_batches = njets // reader.batch_size + 1
+    for i, batch in enumerate(reader.stream(input_groups, num_jets=njets)):
+        if (i+1) % 10 == 0:
+            print(f"Processing batch {i+1}/{num_batches} ({(i+1)/num_batches*100:.2f}%)")
+
+        to_append = merge_dicts(
+            [af(batch) for af in append_function]
+        )
+        for k, newvars in to_append.items():
+            if k not in output_groups:
+                raise ValueError(f"Trying to output to {k} but only {output_groups} are allowed")
+            for newkey, newval in newvars.items():
+                if newkey in batch[k].dtype.names:
+                    raise ValueError(f"Trying to append {newkey} to {k} but it already exists in batch") 
+                if newval.shape != batch[k].shape:
+                    raise ValueError(f"Trying to append {newkey} to {k} but the shape is not correct")
+
+        to_write = {}
+
+        for key, str_array in batch.items():
+            if key not in output_groups:
+                continue
+            if key in to_append:
+                
+                str_array = np.lib.recfunctions.append_fields(
+                    str_array,
+                    list(to_append[key].keys()),
+                    list(to_append[key].values()),
+                    usemask=False,
+                )
+            to_write[key] = str_array
+        if writer is None:
+            writer = H5Writer(
+                output_file,
+                dtypes={key: str_array.dtype for key, str_array in to_write.items()},
+                shapes=get_shape(njets, to_write),
+                shuffle=False,
+                **writer_kwargs,
+            )
+        
+        writer.write(to_write)
+                

--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -3,9 +3,9 @@ import numpy as np
 from ftag.hdf5.h5reader import H5Reader
 from ftag.hdf5.h5writer import H5Writer
 import h5py
-from tqdm import tqdm
 from pathlib import Path
 from typing import Callable
+
 def merge_dicts(dicts):
     """
     Merges a list of dictionaries whre each dict is of the form:

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pytest
-
+from unittest import mock
 from ftag import get_mock_file
 from ftag.hdf5.h5add_col import (
     get_all_groups,
@@ -92,8 +92,6 @@ def test_h5_add_column_allows_overwrite(tmp_path, input_file, append_func):
 
 def test_h5_add_column_default_output_path(input_file, append_func):
     out_path = Path(str(input_file).replace(".h5", "_additional.h5"))
-    if out_path.exists():
-        out_path.unlink()
     h5_add_column(input_file, None, append_func)
     assert out_path.exists()
 
@@ -190,6 +188,21 @@ def test_invalid_python(tmp_path):
     with pytest.raises(SyntaxError):
         parse_append_function(f"{file}:good")
 
+def test_func_path_as_path_object(tmp_path):
+    file = tmp_path / "pathfunc.py"
+    file.write_text("def test_fn():\n    return 42")
+
+    func_path = Path(f"{file}:test_fn")  # Pass Path object (triggers the isinstance check)
+    func = parse_append_function(func_path)
+    assert func() == 42
+
+def test_spec_is_none(tmp_path):
+    file = tmp_path / "fake.py"
+    file.write_text("def f(): pass")
+
+    with mock.patch("importlib.util.spec_from_file_location", return_value=None):
+        with pytest.raises(ImportError, match="Cannot load spec"):
+            parse_append_function(f"{file}:f")
 
 def test_cli(tmp_path, input_file):
     # Gets the path in here

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from unittest import mock
 
 import h5py
 import numpy as np
 import pytest
-from unittest import mock
+
 from ftag import get_mock_file
 from ftag.hdf5.h5add_col import (
     get_all_groups,
@@ -188,6 +189,7 @@ def test_invalid_python(tmp_path):
     with pytest.raises(SyntaxError):
         parse_append_function(f"{file}:good")
 
+
 def test_func_path_as_path_object(tmp_path):
     file = tmp_path / "pathfunc.py"
     file.write_text("def test_fn():\n    return 42")
@@ -196,13 +198,17 @@ def test_func_path_as_path_object(tmp_path):
     func = parse_append_function(func_path)
     assert func() == 42
 
+
 def test_spec_is_none(tmp_path):
     file = tmp_path / "fake.py"
     file.write_text("def f(): pass")
 
-    with mock.patch("importlib.util.spec_from_file_location", return_value=None):
-        with pytest.raises(ImportError, match="Cannot load spec"):
-            parse_append_function(f"{file}:f")
+    with (
+        mock.patch("importlib.util.spec_from_file_location", return_value=None),
+        pytest.raises(ImportError, match="Cannot load spec"),
+    ):
+        parse_append_function(f"{file}:f")
+
 
 def test_cli(tmp_path, input_file):
     # Gets the path in here

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -1,0 +1,68 @@
+import numpy as np
+import h5py
+import pytest
+from pathlib import Path
+
+from ftag import get_mock_file
+from ftag.hdf5 import h5_add_column
+
+
+@pytest.fixture
+def input_file(tmp_path):
+    """Create a mock HDF5 file for testing."""
+    dst = tmp_path / "input.h5"
+    mock = get_mock_file()
+    with h5py.File(dst, "w") as f:
+        f.create_dataset("jets", data=mock[1]["jets"][:100])
+    return dst
+
+
+@pytest.fixture
+def append_func():
+    def add_phi(batch):
+        return {
+            "jets": {
+                "new_phi": batch["jets"]["pt"] * 0.1  # some dummy computation
+            }
+        }
+    return add_phi
+
+
+def test_h5_add_column_creates_output(tmp_path, input_file, append_func):
+    output_file = tmp_path / "output.h5"
+    h5_add_column(input_file, output_file, append_func)
+
+    assert output_file.exists()
+    with h5py.File(output_file, "r") as f:
+        assert "jets" in f
+        assert "new_phi" in f["jets"].dtype.names
+        assert np.allclose(f["jets"]["new_phi"], f["jets"]["pt"][:100] * 0.1)
+
+
+def test_h5_add_column_overwrite_protection(tmp_path, input_file, append_func):
+    output_file = tmp_path / "output.h5"
+    h5_add_column(input_file, output_file, append_func)
+
+    # Attempting to write again should raise unless overwrite=True
+    with pytest.raises(FileExistsError):
+        h5_add_column(input_file, output_file, append_func)
+
+    # Should succeed with overwrite=True
+    h5_add_column(input_file, output_file, append_func, overwrite=True)
+    assert output_file.exists()
+
+
+def test_h5_add_column_invalid_group(tmp_path, input_file, append_func):
+    def wrong_group_func(batch):
+        return {"tracks": {"phi": np.ones(len(batch["jets"]))}}
+
+    with pytest.raises(ValueError, match="Trying to output to"):
+        h5_add_column(input_file, tmp_path / "bad_output.h5", wrong_group_func)
+
+
+def test_h5_add_column_variable_conflict(tmp_path, input_file):
+    def conflict_func(batch):
+        return {"jets": {"pt": np.ones(len(batch["jets"]))}}  # pt already exists
+
+    with pytest.raises(ValueError, match="Trying to append pt to jets but it already exists in batch"):
+        h5_add_column(input_file, tmp_path / "conflict.h5", conflict_func)

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import h5py
@@ -8,16 +9,17 @@ import pytest
 
 from ftag import get_mock_file
 from ftag.hdf5.h5add_col import (
-    get_all_groups, 
-    get_shape, 
-    h5_add_column, 
+    get_all_groups,
+    get_shape,
+    h5_add_column,
     merge_dicts,
-    parse_append_function
-    )
-import subprocess   
+    parse_append_function,
+)
+
 
 def dummy_append_func(batch):
     return {"jets": {"new_phi": batch["jets"]["pt"] * 0.1}}
+
 
 @pytest.fixture
 def input_file():
@@ -152,6 +154,7 @@ def test_skip_tracks(tmp_path, input_file, append_func):
         input_groups=["jets", "tracks"],  # only allow reading from jets
     )
 
+
 def test_valid_function_load(tmp_path):
     # Create a temporary Python file with a test function
     file = tmp_path / "testmod.py"
@@ -161,13 +164,16 @@ def test_valid_function_load(tmp_path):
     assert callable(func)
     assert func() == "bar"
 
+
 def test_invalid_format():
     with pytest.raises(ValueError, match="Function should be specified"):
         parse_append_function("somefile.py")  # Missing ":func"
 
-def test_file_not_found():
+
+def test_append_func_file_not_found():
     with pytest.raises(FileNotFoundError):
         parse_append_function("nonexistent.py:func")
+
 
 def test_attribute_error(tmp_path):
     file = tmp_path / "mod.py"
@@ -176,6 +182,7 @@ def test_attribute_error(tmp_path):
     with pytest.raises(AttributeError, match="has no attribute"):
         parse_append_function(f"{file}:missing_func")
 
+
 def test_invalid_python(tmp_path):
     file = tmp_path / "bad.py"
     file.write_text("def good:\n    pass")  # invalid syntax
@@ -183,18 +190,28 @@ def test_invalid_python(tmp_path):
     with pytest.raises(SyntaxError):
         parse_append_function(f"{file}:good")
 
+
 def test_cli(tmp_path, input_file):
     # Gets the path in here
-    func_path = Path(__file__).parent.parent.parent.parent / 'ftag/tests/hdf5/test_h5add_col.py:dummy_append_func'
+    func_path = (
+        Path(__file__).parent.parent.parent.parent
+        / "ftag/tests/hdf5/test_h5add_col.py:dummy_append_func"
+    )
     output_file = tmp_path / "cli_output.h5"
     arguments = [
         "h5addcol",
-        "--input", str(input_file),
-        "--output", output_file,
-        "--append_func", str(func_path),
+        "--input",
+        str(input_file),
+        "--output",
+        output_file,
+        "--append_func",
+        str(func_path),
     ]
-    
-    subprocess.run(arguments, )
+
+    subprocess.run(
+        arguments,
+        check=False,
+    )
 
     assert output_file.exists()
     with h5py.File(output_file) as f:

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -7,8 +7,17 @@ import numpy as np
 import pytest
 
 from ftag import get_mock_file
-from ftag.hdf5.h5add_col import get_all_groups, get_shape, h5_add_column, merge_dicts
+from ftag.hdf5.h5add_col import (
+    get_all_groups, 
+    get_shape, 
+    h5_add_column, 
+    merge_dicts,
+    parse_append_function
+    )
+import subprocess   
 
+def dummy_append_func(batch):
+    return {"jets": {"new_phi": batch["jets"]["pt"] * 0.1}}
 
 @pytest.fixture
 def input_file():
@@ -18,14 +27,7 @@ def input_file():
 
 @pytest.fixture
 def append_func():
-    def add_phi(batch):
-        return {
-            "jets": {
-                "new_phi": batch["jets"]["pt"] * 0.1  # some dummy computation
-            }
-        }
-
-    return add_phi
+    return dummy_append_func
 
 
 def test_file_not_found():
@@ -149,3 +151,52 @@ def test_skip_tracks(tmp_path, input_file, append_func):
         output_groups=["jets"],  # only allow writing to tracks
         input_groups=["jets", "tracks"],  # only allow reading from jets
     )
+
+def test_valid_function_load(tmp_path):
+    # Create a temporary Python file with a test function
+    file = tmp_path / "testmod.py"
+    file.write_text("def foo():\n    return 'bar'")
+
+    func = parse_append_function(f"{file}:foo")
+    assert callable(func)
+    assert func() == "bar"
+
+def test_invalid_format():
+    with pytest.raises(ValueError, match="Function should be specified"):
+        parse_append_function("somefile.py")  # Missing ":func"
+
+def test_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        parse_append_function("nonexistent.py:func")
+
+def test_attribute_error(tmp_path):
+    file = tmp_path / "mod.py"
+    file.write_text("# no function defined here")
+
+    with pytest.raises(AttributeError, match="has no attribute"):
+        parse_append_function(f"{file}:missing_func")
+
+def test_invalid_python(tmp_path):
+    file = tmp_path / "bad.py"
+    file.write_text("def good:\n    pass")  # invalid syntax
+
+    with pytest.raises(SyntaxError):
+        parse_append_function(f"{file}:good")
+
+def test_cli(tmp_path, input_file):
+    # Gets the path in here
+    func_path = Path(__file__).parent.parent.parent.parent / 'ftag/tests/hdf5/test_h5add_col.py:dummy_append_func'
+    output_file = tmp_path / "cli_output.h5"
+    arguments = [
+        "h5addcol",
+        "--input", str(input_file),
+        "--output", output_file,
+        "--append_func", str(func_path),
+    ]
+    
+    subprocess.run(arguments, )
+
+    assert output_file.exists()
+    with h5py.File(output_file) as f:
+        assert "jets" in f
+        assert "new_phi" in f["jets"].dtype.names

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -28,6 +28,10 @@ def append_func():
         }
     return add_phi
 
+def test_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        h5_add_column("nonexistent.h5", None, lambda x: x)
+
 def test_merge_dicts_success():
     d1 = {"jets": {"pt": np.array([1, 2, 3])}}
     d2 = {"jets": {"eta": np.array([4, 5, 6])}}
@@ -121,3 +125,24 @@ def test_h5_add_column_rejects_wrong_output_group(tmp_path, input_file):
 
     with pytest.raises(ValueError, match="Trying to append phi to tracks"):
         h5_add_column(input_file, tmp_path / "wronggroup.h5", other_group)
+
+def test_output_to_non_writen_group(tmp_path, input_file, append_func):
+    
+    with pytest.raises(ValueError, match="Trying to output to jets but only "):
+        h5_add_column(
+            input_file,
+            tmp_path / "non_writen_group.h5",
+            append_func,
+            output_groups=["tracks"],  # only allow writing to tracks
+            input_groups=["jets", "tracks"],  # only allow reading from jets
+        )
+
+def test_skip_tracks(tmp_path, input_file, append_func):
+    
+    h5_add_column(
+        input_file,
+        tmp_path / "non_writen_group.h5",
+        append_func,
+        output_groups=["jets"],  # only allow writing to tracks
+        input_groups=["jets", "tracks"],  # only allow reading from jets
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ vds = "ftag.vds:main"
 wps = "ftag.working_points:main"
 h5move = "ftag.hdf5.h5move:main"
 h5split = "ftag.hdf5.h5split:main"
+h5addcol = "ftag.hdf5.h5add_col:main"
 
 [tool.setuptools]
 packages = ["ftag", "ftag.hdf5", "ftag.utils"]


### PR DESCRIPTION
## Summary

I very often end up writing the same code which allows me to copy an h5 file while adding a new column. This merge request provides a new helper function which allows this to be done by passing an input file, output file, and a list of callable, where each callable returns a dict of the form `{group : {var1 : data1, var2 : data2}}`


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
