### PR TITLE
Update xbb classes definitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update xbb classes definitions [#122](https://github.com/umami-hep/atlas-ftag-tools/pull/122)
 - Fixing Issues in the Imports & Update Docs [#120](https://github.com/umami-hep/atlas-ftag-tools/pull/120)
 - Updating new Sphinx Docs [#119](https://github.com/umami-hep/atlas-ftag-tools/pull/119)
 - Adding new Sphinx Docs [#118](https://github.com/umami-hep/atlas-ftag-tools/pull/118)

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -117,7 +117,7 @@
   colour: "silver"
   category: xbb
 - name: qcdbx
-  label: QCD->bx
+  label: $\mathrm{QCD} \rightarrow bX$
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 1"]
   colour: "gold"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -132,7 +132,7 @@
   colour: "green"
   category: xbb
 - name: Wqq
-  label: Wqq
+  label: $W \rightarrow q\bar{q}$
   cuts: ["R10TruthLabel_R22v1 == 2", "GhostBHadronsFinalCount < 2", "GhostCHadronsFinalCount < 2"]
   colour: "purple"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -127,7 +127,7 @@
   colour: "pink"
   category: xbb
 - name: qcdll
-  label: QCD->ll
+  label: $\mathrm{QCD} \rightarrow ll$
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 0", "GhostCHadronsFinalCount == 0"]
   colour: "green"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -142,7 +142,7 @@
   colour: "#b40657"
   category: xbb
 - name: htautauhad
-  label: $H \rightarrow \tau\tau$
+  label: $H \rightarrow \tau_{\mathrm{had}} \tau_{\mathrm{had}}$
   cuts: ["R10TruthLabel_R22v1 == 16"]
   colour: "#b406a0"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -112,7 +112,7 @@
   colour: "red"
   category: xbb
 - name: qcdnonbb
-  label: QCD->non-bb
+  label: $\mathrm{QCD} \rightarrow \mathrm{non-} b \bar{b}$
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount != 2"]
   colour: "silver"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -137,7 +137,7 @@
   colour: "#b40612"
   category: xbb
 - name: htautaumu
-  label: $H \rightarrow \tau\tau \rightarrow \mu$
+  label: $H \rightarrow \tau_{\mathrm{had}} \tau_{\mu}$
   cuts: ["R10TruthLabel_R22v1 == 15"]
   colour: "#b40657"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -108,40 +108,40 @@
   category: xbb
 - name: qcdbb
   label: QCD->bb
-  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 2"]
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount >= 2"]
   colour: "red"
   category: xbb
 - name: qcdnonbb
-  label: QCD
+  label: QCD->non-bb
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount != 2"]
   colour: "silver"
   category: xbb
 - name: qcdbx
-  label: QCD
+  label: QCD->bx
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 1"]
   colour: "gold"
   category: xbb
 - name: qcdcx
-  label: QCD
+  label: QCD->cx
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostCHadronsFinalCount >= 1", "GhostBHadronsFinalCount == 0"]
   colour: "pink"
   category: xbb
 - name: qcdll
-  label: QCD
+  label: QCD->ll
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 0", "GhostCHadronsFinalCount == 0"]
   colour: "green"
   category: xbb
-- name: htauel
-  label: $H \rightarrow \tau e$
+- name: htautauel
+  label: $H \rightarrow \tau\tau \rightarrow e$
   cuts: ["R10TruthLabel_R22v1 == 14"]
   colour: "#b40612"
   category: xbb
-- name: htaumu
-  label: $H \rightarrow \tau\mu$
+- name: htautaumu
+  label: $H \rightarrow \tau\tau \rightarrow \mu$
   cuts: ["R10TruthLabel_R22v1 == 15"]
   colour: "#b40657"
   category: xbb
-- name: htauhad
+- name: htautauhad
   label: $H \rightarrow \tau\tau$
   cuts: ["R10TruthLabel_R22v1 == 16"]
   colour: "#b406a0"

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -132,7 +132,7 @@
   colour: "green"
   category: xbb
 - name: htautauel
-  label: $H \rightarrow \tau\tau \rightarrow e$
+  label: $H \rightarrow \tau_{\mathrm{had}} \tau_{e}$
   cuts: ["R10TruthLabel_R22v1 == 14"]
   colour: "#b40612"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -122,7 +122,7 @@
   colour: "gold"
   category: xbb
 - name: qcdcx
-  label: QCD->cx
+  label: $\mathrm{QCD} \rightarrow cX$
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostCHadronsFinalCount >= 1", "GhostBHadronsFinalCount == 0"]
   colour: "pink"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -107,7 +107,7 @@
   colour: "#38761D"
   category: xbb
 - name: qcdbb
-  label: QCD->bb
+  label: $\mathrm{QCD} \rightarrow b \bar{b}$
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount >= 2"]
   colour: "red"
   category: xbb

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -131,6 +131,11 @@
   cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount == 0", "GhostCHadronsFinalCount == 0"]
   colour: "green"
   category: xbb
+- name: Wqq
+  label: Wqq
+  cuts: ["R10TruthLabel_R22v1 == 2", "GhostBHadronsFinalCount < 2", "GhostCHadronsFinalCount < 2"]
+  colour: "purple"
+  category: xbb
 - name: htautauel
   label: $H \rightarrow \tau_{\mathrm{had}} \tau_{e}$
   cuts: ["R10TruthLabel_R22v1 == 14"]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* In the flavours definition, update htau class naming to htautau as per agreed naming convention
* In the flavours definition, update htautau labels to match filter content
* In the flavours definition, update QCD subclass labels to correctly match filter content

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
