### PR TITLE
Remove flavours sorting

### DIFF
--- a/ftag/labeller.py
+++ b/ftag/labeller.py
@@ -30,8 +30,8 @@ class Labeller:
     def __post_init__(self) -> None:
         if isinstance(self.labels, LabelContainer):
             self.labels = list(self.labels)
-        self.labels = sorted([Flavours[label] for label in self.labels])
-
+        self.labels = [Flavours[label] for label in self.labels]
+        
     @property
     def variables(self) -> list[str]:
         """


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Removes alphabetical sorting in labels returned by Labeller

Relates to the following issues

* The alphabetical sorting of labels instead of the output "by index" causes problems downstream in the usage in Salt, see attached slides [RelabellingMatching_BugFix.pdf](https://github.com/user-attachments/files/20614204/RelabellingMatching_BugFix.pdf)



## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
