### PR TITLE
H5 reader and writer improvements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - Updating new Sphinx Docs [#119](https://github.com/umami-hep/atlas-ftag-tools/pull/119)
 - Adding new Sphinx Docs [#118](https://github.com/umami-hep/atlas-ftag-tools/pull/118)
 - Allow writer to write some things at full precision, and the rest at half [#123](https://github.com/umami-hep/atlas-ftag-tools/pull/123)
+- Allow writer to have varying number of jets, fix reader batch sizes [#125](https://github.com/umami-hep/atlas-ftag-tools/pull/125)
 
 ### [v0.2.10]
 

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -11,7 +11,7 @@ import h5py
 import numpy as np
 
 from ftag.cuts import Cuts
-from ftag.hdf5.h5utils import get_dtype, get_num_in_dset
+from ftag.hdf5.h5utils import get_dtype
 from ftag.sample import Sample
 from ftag.transform import Transform
 
@@ -179,7 +179,9 @@ class H5Reader:
 
         # calculate batch sizes
         if self.weights is None:
-            rows_per_file = [get_num_in_dset(f, self.jets_name) for f in self.fname]
+            rows_per_file = [
+                H5SingleReader(f, jets_name=self.jets_name).num_jets for f in self.fname
+            ]
             num_total = sum(rows_per_file)
             self.weights = [num / num_total for num in rows_per_file]
 

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -11,7 +11,7 @@ import h5py
 import numpy as np
 
 from ftag.cuts import Cuts
-from ftag.hdf5.h5utils import get_dtype
+from ftag.hdf5.h5utils import get_dtype, get_num_in_dset
 from ftag.sample import Sample
 from ftag.transform import Transform
 
@@ -179,7 +179,10 @@ class H5Reader:
 
         # calculate batch sizes
         if self.weights is None:
-            self.weights = [1 / len(self.fname)] * len(self.fname)
+            rows_per_file = [get_num_in_dset(f, self.jets_name) for f in self.fname]
+            num_total = sum(rows_per_file)
+            self.weights = [num / num_total for num in rows_per_file]
+
         self.batch_sizes = [int(w * self.batch_size) for w in self.weights]
 
         # create readers

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -79,7 +79,7 @@ class H5SingleReader:
         if num_jets is None:
             num_jets = self.num_jets
         if skip_batches > 0:
-            assert self.shuffle == False, "Cannot skip batches if shuffle is True"
+            assert not self.shuffle, "Cannot skip batches if shuffle is True"
         if num_jets > self.num_jets:
             log.warning(
                 f"{num_jets:,} jets requested but only {self.num_jets:,} available in {self.fname}."

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import h5py
 import numpy as np
 from numpy.lib.recfunctions import unstructured_to_structured as u2s
 

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import h5py
 import numpy as np
 from numpy.lib.recfunctions import unstructured_to_structured as u2s
 
@@ -135,29 +134,3 @@ def structured_from_dict(d: dict[str, np.ndarray]) -> np.ndarray:
     arrays = np.column_stack(list(d.values()))
     dtypes = np.dtype([(k, v.dtype) for k, v in d.items()])
     return u2s(arrays, dtype=dtypes)
-
-
-def get_num_in_dset(h5path: str, group_name: str = "jets") -> int:
-    """Get the number entries in a given dataset in an HDF5 file.
-
-    Parameters
-    ----------
-    h5path : str
-        Path to the HDF5 file
-    group_name : str
-        Name of the group
-
-    Returns
-    -------
-    int
-        Number of datasets in the group
-
-    Raises
-    ------
-    ValueError
-        If the group is not found in the file
-    """
-    with h5py.File(h5path, "r") as f:
-        if group_name not in f:
-            raise ValueError(f"Group {group_name} not found in file {h5path}")
-        return len(f[group_name])

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -13,7 +13,7 @@ def get_dtype(
     variables: list[str] | None = None,
     precision: str | None = None,
     transform: Transform | None = None,
-    full_precision_vars : list[str] | None = None,
+    full_precision_vars: list[str] | None = None,
 ) -> np.dtype:
     """Return a dtype based on an existing dataset and requested variables.
 
@@ -29,6 +29,7 @@ def get_dtype(
         Transform to apply to variables names, by default None
     full_precision_vars : list[str] | None, optional
         List of variables to keep in full precision, by default None
+
     Returns
     -------
     np.dtype
@@ -43,8 +44,6 @@ def get_dtype(
         variables = ds.dtype.names
     if full_precision_vars is None:
         full_precision_vars = []
-    
-
 
     if (missing := set(variables) - set(ds.dtype.names)) and transform is not None:
         variables = transform.map_variable_names(ds.name, variables, inverse=True)
@@ -58,7 +57,8 @@ def get_dtype(
     if precision:
         dtype = [
             (n, cast_dtype(x, precision)) if n not in full_precision_vars else (n, x)
-            for n, x in dtype]
+            for n, x in dtype
+        ]
 
     return np.dtype(dtype)
 
@@ -86,7 +86,7 @@ def cast_dtype(typestr: str, precision: str) -> np.dtype:
     t = np.dtype(typestr)
     if t.kind != "f":
         return t
-    
+
     if precision == "half":
         return np.dtype("f2")
     if precision == "full":
@@ -134,3 +134,29 @@ def structured_from_dict(d: dict[str, np.ndarray]) -> np.ndarray:
     arrays = np.column_stack(list(d.values()))
     dtypes = np.dtype([(k, v.dtype) for k, v in d.items()])
     return u2s(arrays, dtype=dtypes)
+
+
+def get_num_in_dset(h5path: str, group_name: str = "jets") -> int:
+    """Get the number entries in a given dataset in an HDF5 file.
+
+    Parameters
+    ----------
+    h5path : str
+        Path to the HDF5 file
+    group_name : str
+        Name of the group
+
+    Returns
+    -------
+    int
+        Number of datasets in the group
+
+    Raises
+    ------
+    ValueError
+        If the group is not found in the file
+    """
+    with h5py.File(h5path, "r") as f:
+        if group_name not in f:
+            raise ValueError(f"Group {group_name} not found in file {h5path}")
+        return len(f[group_name])

--- a/ftag/hdf5/h5utils.py
+++ b/ftag/hdf5/h5utils.py
@@ -13,6 +13,7 @@ def get_dtype(
     variables: list[str] | None = None,
     precision: str | None = None,
     transform: Transform | None = None,
+    full_precision_vars : list[str] | None = None,
 ) -> np.dtype:
     """Return a dtype based on an existing dataset and requested variables.
 
@@ -26,7 +27,8 @@ def get_dtype(
         Precision to cast floats to, "half" or "full", by default None
     transform : Transform | None, optional
         Transform to apply to variables names, by default None
-
+    full_precision_vars : list[str] | None, optional
+        List of variables to keep in full precision, by default None
     Returns
     -------
     np.dtype
@@ -39,6 +41,10 @@ def get_dtype(
     """
     if variables is None:
         variables = ds.dtype.names
+    if full_precision_vars is None:
+        full_precision_vars = []
+    
+
 
     if (missing := set(variables) - set(ds.dtype.names)) and transform is not None:
         variables = transform.map_variable_names(ds.name, variables, inverse=True)
@@ -50,7 +56,9 @@ def get_dtype(
 
     dtype = [(n, x) for n, x in ds.dtype.descr if n in variables]
     if precision:
-        dtype = [(n, cast_dtype(x, precision)) for n, x in dtype]
+        dtype = [
+            (n, cast_dtype(x, precision)) if n not in full_precision_vars else (n, x)
+            for n, x in dtype]
 
     return np.dtype(dtype)
 
@@ -78,6 +86,7 @@ def cast_dtype(typestr: str, precision: str) -> np.dtype:
     t = np.dtype(typestr)
     if t.kind != "f":
         return t
+    
     if precision == "half":
         return np.dtype("f2")
     if precision == "full":

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -43,13 +43,22 @@ class H5Writer:
     compression: str = "lzf"
     precision: str = "full"
     shuffle: bool = True
+    num_jets: int | None = None  # Allow dynamic mode by defaulting to None
+    full_precision_vars: list[str] = None  # List of variables to store in full precision
 
     def __post_init__(self):
         self.num_written = 0
         self.rng = np.random.default_rng(42)
-        self.num_jets = [shape[0] for shape in self.shapes.values()]
-        assert len(set(self.num_jets)) == 1, "Must have same number of jets per group"
-        self.num_jets = self.num_jets[0]
+
+        # Infer number of jets from shapes if not explicitly passed
+        inferred_num_jets = [shape[0] for shape in self.shapes.values()]
+        if self.num_jets is None:
+            assert len(set(inferred_num_jets)) == 1, "Shapes must agree in first dimension"
+            self.fixed_mode = False
+        else:
+            self.fixed_mode = True
+            for name in self.shapes:
+                self.shapes[name] = (self.num_jets,) + self.shapes[name][1:]
 
         if self.precision == "full":
             self.fp_dtype = np.float32
@@ -58,6 +67,8 @@ class H5Writer:
         else:
             raise ValueError(f"Invalid precision: {self.precision}")
 
+        if self.full_precision_vars is None:
+            self.full_precision_vars = []
         self.dst = Path(self.dst)
         self.dst.parent.mkdir(parents=True, exist_ok=True)
         self.file = h5py.File(self.dst, "w")
@@ -67,11 +78,29 @@ class H5Writer:
             self.create_ds(name, dtype)
 
     @classmethod
-    def from_file(cls, source: Path, num_jets: int | None = None, **kwargs) -> H5Writer:
+    def from_file(
+        cls, source: Path, num_jets: int | None = 0, variables=None, **kwargs
+    ) -> H5Writer:
         with h5py.File(source, "r") as f:
             dtypes = {name: ds.dtype for name, ds in f.items()}
             shapes = {name: ds.shape for name, ds in f.items()}
-            if num_jets is not None:
+
+            if variables:
+                new_dtye = {}
+                new_shape = {}
+                for name, ds in f.items():
+                    if name not in variables:
+                        continue
+                    new_dtye[name] = ftag.hdf5.get_dtype(
+                        ds,
+                        variables=variables[name],
+                        precision=kwargs.get("precision"),
+                        full_precision_vars=kwargs.get("full_precision_vars"),
+                    )
+                    new_shape[name] = ds.shape
+                dtypes = new_dtye
+                shapes = new_shape
+            if num_jets != 0:
                 shapes = {name: (num_jets,) + shape[1:] for name, shape in shapes.items()}
             compression = [ds.compression for ds in f.values()]
             assert len(set(compression)) == 1, "Must have same compression for all groups"
@@ -83,30 +112,47 @@ class H5Writer:
     def create_ds(self, name: str, dtype: np.dtype) -> None:
         if name == self.jets_name and self.add_flavour_label and "flavour_label" not in dtype.names:
             dtype = np.dtype([*dtype.descr, ("flavour_label", "i4")])
-
-        # adjust dtype based on specified precision
+        print("FP vars: ", self.full_precision_vars)
+        # If the dtype is a float, and its not in the full precision vars, convert it to the specified precision
+        # otherwise, keep it the same dtype
         dtype = np.dtype([
-            (field, self.fp_dtype if np.issubdtype(dt, np.floating) else dt)
+            (
+                field,
+                (
+                    self.fp_dtype
+                    if (field not in self.full_precision_vars) and np.issubdtype(dt, np.floating)
+                    else dt
+                ),
+            )
             for field, dt in dtype.descr
         ])
 
-        # optimal chunking is around 100 jets, only aply for track groups
         shape = self.shapes[name]
         chunks = (100,) + shape[1:] if shape[1:] else None
 
-        # note: enabling the hd5 shuffle filter doesn't improve write performance
-        self.file.create_dataset(
-            name, dtype=dtype, shape=shape, compression=self.compression, chunks=chunks
-        )
+        if self.fixed_mode:
+            self.file.create_dataset(
+                name, dtype=dtype, shape=shape, compression=self.compression, chunks=chunks
+            )
+        else:
+            maxshape = (None,) + shape[1:]
+            self.file.create_dataset(
+                name,
+                dtype=dtype,
+                shape=(0,) + shape[1:],
+                maxshape=maxshape,
+                compression=self.compression,
+                chunks=chunks,
+            )
 
     def close(self) -> None:
-        with h5py.File(self.dst) as f:
-            written = len(f[self.jets_name])
-        if self.num_written != written:
-            raise ValueError(
-                f"Attemped to close file {self.dst} when only {self.num_written:,} out of"
-                f" {written:,} jets have been written"
-            )
+        if self.fixed_mode:
+            written = len(self.file[self.jets_name])
+            if self.num_written != written:
+                raise ValueError(
+                    f"Attempted to close file {self.dst} when only {self.num_written:,} out of"
+                    f" {written:,} jets have been written"
+                )
         self.file.close()
 
     def get_attr(self, name, group=None):
@@ -126,18 +172,26 @@ class H5Writer:
                 for attr_name, value in ds.attrs.items():
                     self.add_attr(attr_name, value, group=name)
 
-    def write(self, data: dict[str, np.array]) -> None:
-        if (total := self.num_written + len(data[self.jets_name])) > self.num_jets:
-            raise ValueError(
-                f"Attempted to write more jets than expected: {total:,} > {self.num_jets:,}"
-            )
-        idx = np.arange(len(data[self.jets_name]))
+    def write(self, data: dict[str, np.ndarray]) -> None:
+        batch_size = len(data[self.jets_name])
+        idx = np.arange(batch_size)
         if self.shuffle:
             self.rng.shuffle(idx)
             data = {name: array[idx] for name, array in data.items()}
 
         low = self.num_written
-        high = low + len(idx)
+        high = low + batch_size
+
+        if self.fixed_mode:
+            if high > self.num_jets:
+                raise ValueError(
+                    f"Attempted to write more jets than expected: {high:,} > {self.num_jets:,}"
+                )
+
         for group in self.dtypes:
-            self.file[group][low:high] = data[group]
-        self.num_written += len(idx)
+            ds = self.file[group]
+            if not self.fixed_mode:
+                ds.resize((high,) + ds.shape[1:])
+            ds[low:high] = data[group]
+
+        self.num_written += batch_size

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -72,8 +72,6 @@ class H5Writer:
         else:
             raise ValueError(f"Invalid precision: {self.precision}")
 
-        if self.full_precision_vars is None:
-            self.full_precision_vars = []
         self.dst = Path(self.dst)
         self.dst.parent.mkdir(parents=True, exist_ok=True)
         self.file = h5py.File(self.dst, "w")
@@ -118,6 +116,7 @@ class H5Writer:
         if name == self.jets_name and self.add_flavour_label and "flavour_label" not in dtype.names:
             dtype = np.dtype([*dtype.descr, ("flavour_label", "i4")])
 
+        fp_vars = self.full_precision_vars or []
         # If no precision is defined, or the field is in full_precision_vars, or its non-float,
         # keep it at the original dtype
         dtype = np.dtype([
@@ -125,11 +124,7 @@ class H5Writer:
                 field,
                 (
                     self.fp_dtype
-                    if (
-                        self.fp_dtype
-                        and field not in self.full_precision_vars
-                        and np.issubdtype(dt, np.floating)
-                    )
+                    if (self.fp_dtype and field not in fp_vars and np.issubdtype(dt, np.floating))
                     else dt
                 ),
             )

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -342,7 +342,7 @@ def test_skip_batches(tmp_path):
 
     reader = H5Reader(fpath, batch_size=batch_size, shuffle=False)
 
-    # Skip first 2 batches (i.e., skip jets 0–199)
+    # Skip first 2 batches (i.e., skip jets 0-199)
     skip_batches = 2
     indices_seen = []
     for batch in reader.stream({"jets": ["index"]}, skip_batches=skip_batches):

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -21,7 +21,7 @@ np.random.seed(42)
 @pytest.mark.parametrize("num", [1, 2, 3])
 @pytest.mark.parametrize("length", [200, 301])
 @pytest.mark.parametrize("equal_jets", [True, False])
-def test_H5Reader(num, length, equal_jets):  # noqa: PLR0915
+def test_H5Reader(num, length, equal_jets):
     # calculate all possible effective batch sizes, from single file batch sizes and remainders
     batch_size = 100
     effective_bs_file = batch_size // num
@@ -86,11 +86,8 @@ def test_H5Reader(num, length, equal_jets):  # noqa: PLR0915
             assert (jet == trk).all()
 
         if num > 1:
-            if len(np.unique(data["jets"]["x"])) == 1:
-                np.testing.assert_array_equal(data["jets"]["x"], data["tracks"]["a"][:, 0])
-            else:
-                corr = np.corrcoef(data["jets"]["x"], data["tracks"]["a"][:, 0])
-                np.testing.assert_allclose(corr, 1)
+            corr = np.corrcoef(data["jets"]["x"], data["tracks"]["a"][:, 0])
+            np.testing.assert_allclose(corr, 1)
 
     # testing load method
     loaded_data = reader.load(num_jets=-1)

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -21,7 +21,7 @@ np.random.seed(42)
 @pytest.mark.parametrize("num", [1, 2, 3])
 @pytest.mark.parametrize("length", [200, 301])
 @pytest.mark.parametrize("equal_jets", [True, False])
-def test_H5Reader(num, length, equal_jets):
+def test_H5Reader(num, length, equal_jets):  # noqa: PLR0915
     # calculate all possible effective batch sizes, from single file batch sizes and remainders
     batch_size = 100
     effective_bs_file = batch_size // num

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -193,6 +193,6 @@ def test_precision_none_preserves_dtypes(tmp_path, mock_data):
             for field in dtypes[name].names:
                 expected_dtype = dtypes[name][field]
                 actual_dtype = f[name].dtype[field]
-                assert actual_dtype == expected_dtype, (
-                    f"{name}.{field} was {actual_dtype}, expected {expected_dtype}"
-                )
+                assert (
+                    actual_dtype == expected_dtype
+                ), f"{name}.{field} was {actual_dtype}, expected {expected_dtype}"

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -193,9 +193,9 @@ def test_precision_none_preserves_dtypes(tmp_path, mock_data):
             for field in dtypes[name].names:
                 expected_dtype = dtypes[name][field]
                 actual_dtype = f[name].dtype[field]
-                assert actual_dtype == expected_dtype, (
-                    f"{name}.{field} was {actual_dtype}, expected {expected_dtype}"
-                )
+                assert (
+                    actual_dtype == expected_dtype
+                ), f"{name}.{field} was {actual_dtype}, expected {expected_dtype}"
 
 
 def test_close_raises_on_incomplete_write(tmp_path, jet_dtype):

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -193,9 +193,9 @@ def test_precision_none_preserves_dtypes(tmp_path, mock_data):
             for field in dtypes[name].names:
                 expected_dtype = dtypes[name][field]
                 actual_dtype = f[name].dtype[field]
-                assert (
-                    actual_dtype == expected_dtype
-                ), f"{name}.{field} was {actual_dtype}, expected {expected_dtype}"
+                assert actual_dtype == expected_dtype, (
+                    f"{name}.{field} was {actual_dtype}, expected {expected_dtype}"
+                )
 
 
 def test_close_raises_on_incomplete_write(tmp_path, jet_dtype):
@@ -223,8 +223,10 @@ def test_from_file_with_variable_subset(tmp_path):
     with h5py.File(path, "w") as f:
         jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4"), ("phi", "f4")])
         tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
+        flows = np.zeros((10, 5), dtype=[("pt", "f4")])
         f.create_dataset("jets", data=jets, compression="lzf")
         f.create_dataset("tracks", data=tracks, compression="lzf")
+        f.create_dataset("flows", data=flows, compression="lzf")
 
     # Only want a subset of variables
     variables = {

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -79,7 +79,10 @@ def test_add_attr(tmp_path, jet_dtype):
 
 def test_post_init(tmp_path, jet_dtype):
     writer = H5Writer(
-        dst=Path(tmp_path) / "test.h5", dtypes={"jets": jet_dtype}, shapes={"jets": (100,)}
+        dst=Path(tmp_path) / "test.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        num_jets=100,
     )
 
     assert writer.num_jets == 100
@@ -89,7 +92,10 @@ def test_post_init(tmp_path, jet_dtype):
 
 def test_invalid_write(tmp_path, jet_dtype):
     writer = H5Writer(
-        dst=Path(tmp_path) / "test.h5", dtypes={"jets": jet_dtype}, shapes={"jets": (100,)}
+        dst=Path(tmp_path) / "test.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        num_jets=100,
     )
 
     data = {"jets": np.zeros(110, dtype=writer.dtypes["jets"])}


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Allow H5 Writer to take 'num_jets=None'. In this case, the writer automatically re-shapes for each written batch, allowing indefinite size.
* Allow H5Writer to take 'precision=None'. In this case, the writer will respect the input data types
* Modify H5Reader to automatically calculate weights based on the number of jets in each constituent file - this ensures each batch will have equal size until the last batch.
* Add a 'skip batches' option to H5Reader, which allows the stream to start at a given batch index. This allows more simple splitting of workloads, e.g. writer1 starts at batch0 and runs 100 batches, writer2 starts at batch 101 and runs 100 batches, ... etc


## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
