### PR TITLE
Fix compression in H5Writer

### DIFF
--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -108,7 +108,7 @@ class H5Writer:
             compression = [ds.compression for ds in f.values()]
             assert len(set(compression)) == 1, "Must have same compression for all groups"
             compression = compression[0]
-            if compression not in kwargs:
+            if 'compression' not in kwargs:
                 kwargs["compression"] = compression
         return cls(dtypes=dtypes, shapes=shapes, **kwargs)
 


### PR DESCRIPTION
When using the 'from_file' option in H5Writer, the default behaviour is to copy the compression of the input file. However, if we instead pass 'compression='gzip'' this should overwrite. In the current code, this is not the case as we are instead checking the kwargs for the name of the compression, not the word 'compression' itself. This fixes this.

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
