### PR TITLE
Minor qcdnonbb definition update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Minor qcdnonbb definition update [#127](https://github.com/umami-hep/atlas-ftag-tools/pull/127)
+
 ### [v0.2.11]
 
 - Regex integration for vds merging [#116](https://github.com/umami-hep/atlas-ftag-tools/pull/116)

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 ### [Latest]
 
 - Minor qcdnonbb definition update [#127](https://github.com/umami-hep/atlas-ftag-tools/pull/127)
+- Remove flavours sorting in Labeller [#124](https://github.com/umami-hep/atlas-ftag-tools/pull/124)
+- Allow writer to have varying number of jets, fix reader batch sizes [#125](https://github.com/umami-hep/atlas-ftag-tools/pull/125)
 
 ### [v0.2.11]
 

--- a/ftag/flavours.yaml
+++ b/ftag/flavours.yaml
@@ -113,7 +113,7 @@
   category: xbb
 - name: qcdnonbb
   label: $\mathrm{QCD} \rightarrow \mathrm{non-} b \bar{b}$
-  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount != 2"]
+  cuts: ["R10TruthLabel_R22v1 == 10", "GhostBHadronsFinalCount < 2"]
   colour: "silver"
   category: xbb
 - name: qcdbx


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* qcd-nonbb and qcdbb classes have to be mutually exclusive
*

Relates to the following issues

*
*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
