### PR TITLE
Ensure that the mock file is deterministic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Ensure that the mock file generation is deterministic [#130](https://github.com/umami-hep/atlas-ftag-tools/pull/130)
 - Remove flavours sorting in Labeller [#124](https://github.com/umami-hep/atlas-ftag-tools/pull/124)
 - Allow writer to have varying number of jets, fix reader batch sizes [#125](https://github.com/umami-hep/atlas-ftag-tools/pull/125)
 

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -106,11 +106,11 @@ def get_mock_scores(labels: np.ndarray, is_xbb: bool = False) -> np.ndarray:
     for i in range(n_classes):
         tmp_means = []
         tmp_means = [
-            0 if j != i else mean_scale_list[np.random.randint(0, len(mean_scale_list))]
+            0 if j != i else mean_scale_list[rng.integers(0, len(mean_scale_list))]
             for j in range(n_classes)
         ]
         means.append(tmp_means)
-        scales.append(mean_scale_list[np.random.randint(0, len(mean_scale_list))])
+        scales.append(mean_scale_list[rng.integers(0, len(mean_scale_list))])
 
     # Map the labels to the means
     label_mapping = dict(zip(label_dict.values(), means))

--- a/ftag/tests/test_mock.py
+++ b/ftag/tests/test_mock.py
@@ -62,3 +62,15 @@ def test_get_mock_file():
     # test custom fname
     fname, f = get_mock_file(fname="test.h5")
     assert fname == "test.h5"
+
+
+def test_get_mock_file_determinism():
+    # Test that the mock file generation is deterministic
+    _, f1 = get_mock_file(num_jets=1000)
+    _, f2 = get_mock_file(num_jets=1000)
+
+    np.testing.assert_array_equal(f1["jets"], f2["jets"])
+    np.testing.assert_array_equal(f1["tracks"], f2["tracks"]) if "tracks" in f1 else True
+
+    # Clean up the file
+    f1.close()


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Ensures that the mock file generation is deterministic


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
