### PR TITLE
Find metadata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ### [Latest]
-
+- Added `find_metadata` script for injecting metadata into `.h5` files [#133](https://github.com/umami-hep/atlas-ftag-tools/pull/133)
 - Allow not doing checks with sample.py [#138](https://github.com/umami-hep/atlas-ftag-tools/pull/138)
 
 ### [v0.2.14](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.2.14) (01.07.2025)

--- a/ftag/example_metadata.yaml
+++ b/ftag/example_metadata.yaml
@@ -1,0 +1,25 @@
+# YAML fallback example for find_metadata.py (only ONE of the following two formats is allowed, and only ONE entry total)
+# ==========
+# Option 1: Use a container name (recommended — the script will parse DSID, etag, and campaign and query the PMG database)
+
+# container name: mc20_13TeV.364703.Pythia8EvtGen_A14NNPDF23LO_jetjet_JZ3WithSW.deriv.DAOD_JETM2.e7142_s3681_r13144_p5548
+# ↑ Replace the line above (uncomment it) with the dataset you want to inject metadata for.
+# ↑ The script will extract the following automatically:
+#    - DSID (e.g. 364704)
+#    - etag (e.g. e7142)
+#    - campaign (e.g. mc20, mc21, etc.)
+#    Then it will look up the PMG xsecDB file to inject the corresponding metadata.
+
+# ==========
+
+# Option 2: Manually provide metadata (bypass PMG query entirely)
+
+123456:  # ← This is the DSID you want to inject metadata for
+  cross_section_pb: 0.12345  # ← Cross-section in pb
+  genFiltEff: 0.934          # ← Generator filter efficiency
+  kfactor: 1.05              # ← K-factor
+
+# Notes:
+# - This YAML file must contain ONLY ONE entry (either a container name or a DSID key)
+# - You cannot mix formats — container name and DSID must not coexist
+# - You cannot provide multiple DSID entries — only one is allowed

--- a/ftag/find_metadata.py
+++ b/ftag/find_metadata.py
@@ -3,12 +3,36 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 import h5py
+import requests
+import yaml
 
-# Mapping of campaign to local database file name
+"""
+find_metadata.py
+
+Injects metadata (cross_section_pb, genFiltEff, kfactor) into .h5 files produced by TDD.
+
+Usage:
+    python find_metadata.py <h5_file1> [<h5_file2> ...] [-m fallback.yaml]
+
+Modes:
+    1. Auto mode (default):
+        - Extract ATLAS BigPanDA Task ID from filename
+        - Query BigPanDA → extract task info → parse DSID/etag/campaign
+        - Query PMGxsecDB and write metadata into /metadata/<DSID>/ in the .h5 file
+
+    2. Fallback mode (-m):
+        - If auto lookup fails, use a YAML file to inject metadata manually
+        - YAML must contain exactly one entry (see example_metadata.yaml)
+
+Example:
+    python find_metadata.py user.username.taskid._000001.h5
+    python find_metadata.py localdump.h5 -m fallback.yaml
+"""
+
 XSECDB_MAP = {
     "mc15": "PMGxsecDB_mc15.txt",
     "mc16": "PMGxsecDB_mc16.txt",
@@ -19,35 +43,87 @@ XSECDB_MAP = {
 XSECDB_URL_BASE = "https://atlas-groupdata.web.cern.ch/atlas-groupdata/dev/PMGTools/"
 
 
+def validate_url_scheme(url: str):
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
+    return parsed
+
+
 def download_xsecdb_files():
     for filename in XSECDB_MAP.values():
         if not Path(filename).exists():
             url = XSECDB_URL_BASE + filename
             try:
+                validate_url_scheme(url)
                 print(f"Downloading {filename} from {url}")
-                urllib.request.urlretrieve(url, filename)  # noqa: S310
+                response = requests.get(url, timeout=10)
+                response.raise_for_status()
+                Path(filename).write_bytes(response.content)
                 print(f"Downloaded: {filename}")
-            except urllib.error.URLError as e:
+            except (requests.RequestException, ValueError) as e:
                 print(f"ERROR: Failed to download {filename} - {e}")
 
 
-def parse_line(container_name):
-    match = re.match(r"(mc\d+)_13TeV\.(\d{6})\..*\.e(\d+)_", container_name)
+def extract_taskid_from_filename(h5_path: Path) -> str | None:
+    m = re.search(r"\.(\d{8})\.", h5_path.name)
+    return m.group(1) if m else None
+
+
+def fetch_taskinfo_from_bigpanda(taskid: str) -> dict | None:
+    url = f"https://bigpanda.cern.ch/tasks/?jeditaskid={taskid}&json"
+    print(f"Fetching task info from: {url}")
+    try:
+        validate_url_scheme(url)
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, list) and data:
+            return data[0]
+        print("No task info found.")
+    except (requests.RequestException, ValueError, json.JSONDecodeError) as e:
+        print(f"ERROR: Failed to fetch task info for {taskid} - {e}")
+    return None
+
+
+def extract_mc_container_from_json(data: dict) -> str | None:
+    text = json.dumps(data)
+    match = re.search(r"(mc\d+_13TeV\.[\w\.]+)", text)
+    return match.group(1) if match else None
+
+
+def parse_line_from_taskname(taskname: str):
+    match = re.match(r".*\.(\d{6})\.e(\d+)_", taskname)
     if match:
-        raw_campaign, dsid, etag = match.groups()
+        dsid, etag = match.groups()
+        return int(dsid), f"e{etag}"
+    return None, None
+
+
+def parse_campaign_from_taskname(taskname: str) -> str | None:
+    m = re.match(r"(mc\d+)_13TeV", taskname)
+    if m:
+        raw_campaign = m.group(1)
+        return "mc16" if raw_campaign == "mc20" else raw_campaign
+    return None
+
+
+def extract_info_from_container(container: str) -> tuple[int, str, str] | None:
+    m_campaign = re.search(r"\b(mc\d+)_13TeV", container)
+    m_dsid = re.search(r"\.(\d{6})\.", container)
+    m_etag = re.search(r"\.e(\d+)(?:[_.]|$)", container)
+    if m_campaign and m_dsid and m_etag:
+        raw_campaign = m_campaign.group(1)
         campaign = "mc16" if raw_campaign == "mc20" else raw_campaign
-        print(
-            f"Parsed container '{container_name}' -> "
-            f"Campaign: {raw_campaign}, PMG Campaign: {campaign}, "
-            f"DSID: {dsid}, etag: e{etag}"
-        )
-        return raw_campaign, campaign, int(dsid), f"e{etag}"
-    print(f"ERROR: Failed to parse container '{container_name}'")
-    return None, None, None, None
+        dsid = int(m_dsid.group(1))
+        etag = f"e{m_etag.group(1)}"
+        return dsid, etag, campaign
+    return None
 
 
 def query_xsecdb(campaign, dsid, etag):
     db_path = XSECDB_MAP.get(campaign)
+    print(f"Searching in {db_path} for DSID={dsid}, etag={etag}")
     if not db_path or not Path(db_path).exists():
         print(f"ERROR: Database file for campaign '{campaign}' not found.")
         return None
@@ -60,98 +136,143 @@ def query_xsecdb(campaign, dsid, etag):
             if len(fields) < 9:
                 continue
             if str(dsid) == fields[0] and etag == fields[8]:
-                print(f"Found metadata for DSID {dsid} and etag {etag} in campaign '{campaign}'")
+                print(f"Match found in {db_path}")
                 return {
                     "cross_section_pb": float(fields[2]),
                     "genFiltEff": float(fields[3]),
                     "kfactor": float(fields[4]),
                     "etag": fields[8],
                 }
-    print(f"ERROR: Metadata for DSID {dsid} and etag {etag} not found in campaign '{campaign}'")
+    print(f"No match found for DSID={dsid}, etag={etag} in {db_path}")
     return None
 
 
-def write_metadata_to_h5(h5_filename, metadata_dict):
+def write_metadata_to_h5(h5_filename, dsid, metadata_dict):
     with h5py.File(h5_filename, "a") as f:
         meta_group = f.require_group("metadata")
-        for dsid_str, meta in metadata_dict.items():
-            dsid_group = meta_group.require_group(dsid_str)
-            for key in ["cross_section_pb", "genFiltEff", "kfactor"]:
-                if key in dsid_group:
-                    del dsid_group[key]
-                dsid_group.create_dataset(key, data=meta[key])
+        dsid_group = meta_group.require_group(str(dsid))
+        for key in ["cross_section_pb", "genFiltEff", "kfactor"]:
+            if key in dsid_group:
+                del dsid_group[key]
+            dsid_group.create_dataset(key, data=metadata_dict[key])
+            print(f"Wrote {key} = {metadata_dict[key]} to metadata/{dsid}/{key}")
 
 
-def process_container_list(input_file, output_file, h5_merge_file=None):
-    result = {}
-    error_log = output_file.replace(".json", "_errors.log")
-    error_lines = []
+def handle_yaml_fallback(h5_path: Path, yaml_data: dict):
+    if len(yaml_data) != 1:
+        raise ValueError("YAML fallback file must contain exactly one entry")
 
-    print(f"Processing container list from file '{input_file}'")
-    with open(input_file) as f:
-        for line in f:
-            container = line.strip()
-            if not container:
-                continue
-            raw_campaign, campaign, dsid, etag = parse_line(container)
-            if not campaign or not dsid or not etag:
-                msg = f"[Skipped] Unable to parse container: {container}"
-                print(msg)
-                error_lines.append(msg)
-                continue
-            metadata = query_xsecdb(campaign, dsid, etag)
-            if metadata:
-                metadata["campaign"] = (
-                    f"{raw_campaign} (fallback to {campaign})"
-                    if raw_campaign != campaign
-                    else campaign
-                )
-                result[str(dsid)] = metadata
-            else:
-                msg = (
-                    f"ERROR: DSID {dsid} ({raw_campaign}) lookup failed, " f"container: {container}"
-                )
-                print(msg)
-                error_lines.append(msg)
-
-    print(f"Writing successful results to file '{output_file}'")
-    with open(output_file, "w") as out_f:
-        json.dump(result, out_f, indent=2)
-
-    if error_lines:
-        print(f"Writing error logs to file '{error_log}'")
-        with open(error_log, "w") as err_f:
-            for err in error_lines:
-                err_f.write(err + "\n")
-
-    if h5_merge_file:
-        print(f"Merging metadata into HDF5 file: {h5_merge_file}")
+    key, value = next(iter(yaml_data.items()))
+    if key == "container name":
+        if not isinstance(value, str):
+            raise ValueError("'container name' must be a string")
+        container = value
+        print(f"YAML container fallback: {container}")
+        info = extract_info_from_container(container)
+        if not info:
+            raise ValueError(
+                f"Failed to parse valid DSID / etag / campaign from container: {container}"
+            )
+        dsid, etag, campaign = info
+        meta = query_xsecdb(campaign, dsid, etag)
+        if not meta:
+            raise ValueError(f"Container not found in PMG database: {container}")
+    else:
         try:
-            write_metadata_to_h5(h5_merge_file, result)
-            print(f"Successfully merged metadata into {h5_merge_file}")
-        except (OSError, RuntimeError) as e:
-            print(f"ERROR during HDF5 merge: {e}")
+            dsid = int(key)
+        except ValueError as e:
+            raise ValueError("YAML key must be a valid DSID or 'container name'") from e
+        meta = value
+        required_keys = {"cross_section_pb", "genFiltEff", "kfactor"}
+        if not isinstance(meta, dict) or not required_keys.issubset(meta):
+            raise ValueError(
+                "Manual metadata must include: cross_section_pb / genFiltEff / kfactor"
+            )
+
+    write_metadata_to_h5(str(h5_path), dsid, meta)
+    print(f"YAML metadata written to {h5_path.name} for DSID {dsid}")
+
+
+def parse_args_and_yaml():
+    parser = argparse.ArgumentParser(
+        description="Inject metadata into .h5 files via BigPanDA or YAML fallback."
+    )
+    parser.add_argument("h5_files", nargs="+", help="List of .h5 files")
+    parser.add_argument("-m", "--manual-yaml", help="Manual metadata YAML fallback file")
+    args = parser.parse_args()
+
+    yaml_data = {}
+    if args.manual_yaml:
+        with open(args.manual_yaml) as f:
+            yaml_data = yaml.safe_load(f)
+
+    return args.h5_files, yaml_data
+
+
+def process_single_file(path: Path, yaml_data: dict):
+    if not path.exists():
+        print(f"File not found: {path}")
+        return
+
+    taskid = extract_taskid_from_filename(path)
+    if taskid:
+        print(f"Extracted Task ID: {taskid}")
+        taskinfo = fetch_taskinfo_from_bigpanda(taskid)
+        if taskinfo:
+            taskname = taskinfo.get("taskname", "")
+            dsid, etag = parse_line_from_taskname(taskname)
+            container = extract_mc_container_from_json(taskinfo)
+            campaign = parse_campaign_from_taskname(container or "")
+            if dsid and etag and campaign:
+                print(
+                    f"Matched info: DSID={dsid}, etag={etag}, "
+                    f"campaign={campaign}, container={container}"
+                )
+                meta = query_xsecdb(campaign, dsid, etag)
+                if meta:
+                    meta["campaign"] = campaign
+                    print(
+                        f"Got metadata: cross_section = {meta['cross_section_pb']} pb, "
+                        f"eff = {meta['genFiltEff']}, "
+                        f"k = {meta['kfactor']}"
+                    )
+                    try:
+                        write_metadata_to_h5(str(path), dsid, meta)
+                        print(f"Metadata written to {path.name}")
+                    except (OSError, ValueError) as e:
+                        print(f"Failed to write metadata: {e}")
+                    else:
+                        return
+    else:
+        print("Failed to extract Task ID from filename")
+
+    if yaml_data:
+        try:
+            print("Using YAML fallback path")
+            handle_yaml_fallback(path, yaml_data)
+        except (ValueError, KeyError, OSError) as e:
+            print(f"YAML fallback failed: {e}")
+    else:
+        print("Failed to retrieve metadata and no YAML fallback provided")
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Lookup cross-section metadata for containers " "and optionally merge into HDF5"
-    )
-    parser.add_argument(
-        "-i", "--input", required=True, help="Input txt file containing container names"
-    )
-    parser.add_argument("-o", "--output", default="metadata.json", help="Output JSON file name")
-    parser.add_argument(
-        "-m",
-        "--merge",
-        metavar="H5FILE",
-        help="If provided, merge the result into the specified HDF5 file",
-    )
-    args = parser.parse_args()
-
+    h5_files, yaml_data = parse_args_and_yaml()
     download_xsecdb_files()
-    process_container_list(args.input, args.output, args.merge)
+
+    for h5_file in h5_files:
+        print(f"\n==================== Processing {h5_file} ====================\n")
+        process_single_file(Path(h5_file), yaml_data)
+
+    for filename in XSECDB_MAP.values():
+        path = Path(filename)
+        if path.exists():
+            try:
+                path.unlink()
+                print(f"Deleted temporary file: {filename}")
+            except OSError as e:
+                print(f"Failed to delete {filename}: {e}")
 
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":
     main()

--- a/ftag/find_metadata.py
+++ b/ftag/find_metadata.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import urllib.request
+from pathlib import Path
+
+import h5py
+
+# Mapping of campaign to local database file name
+XSECDB_MAP = {
+    "mc15": "PMGxsecDB_mc15.txt",
+    "mc16": "PMGxsecDB_mc16.txt",
+    "mc21": "PMGxsecDB_mc21.txt",
+    "mc23": "PMGxsecDB_mc23.txt",
+}
+
+XSECDB_URL_BASE = "https://atlas-groupdata.web.cern.ch/atlas-groupdata/dev/PMGTools/"
+
+
+def download_xsecdb_files():
+    for filename in XSECDB_MAP.values():
+        if not Path(filename).exists():
+            url = XSECDB_URL_BASE + filename
+            try:
+                print(f"Downloading {filename} from {url}")
+                urllib.request.urlretrieve(url, filename)  # noqa: S310
+                print(f"Downloaded: {filename}")
+            except urllib.error.URLError as e:
+                print(f"ERROR: Failed to download {filename} - {e}")
+
+
+def parse_line(container_name):
+    match = re.match(r"(mc\d+)_13TeV\.(\d{6})\..*\.e(\d+)_", container_name)
+    if match:
+        raw_campaign, dsid, etag = match.groups()
+        campaign = "mc16" if raw_campaign == "mc20" else raw_campaign
+        print(
+            f"Parsed container '{container_name}' -> "
+            f"Campaign: {raw_campaign}, PMG Campaign: {campaign}, "
+            f"DSID: {dsid}, etag: e{etag}"
+        )
+        return raw_campaign, campaign, int(dsid), f"e{etag}"
+    print(f"ERROR: Failed to parse container '{container_name}'")
+    return None, None, None, None
+
+
+def query_xsecdb(campaign, dsid, etag):
+    db_path = XSECDB_MAP.get(campaign)
+    if not db_path or not Path(db_path).exists():
+        print(f"ERROR: Database file for campaign '{campaign}' not found.")
+        return None
+    with open(db_path) as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            if not line or line.startswith("#"):
+                continue
+            fields = line.split()
+            if len(fields) < 9:
+                continue
+            if str(dsid) == fields[0] and etag == fields[8]:
+                print(f"Found metadata for DSID {dsid} and etag {etag} in campaign '{campaign}'")
+                return {
+                    "cross_section_pb": float(fields[2]),
+                    "genFiltEff": float(fields[3]),
+                    "kfactor": float(fields[4]),
+                    "etag": fields[8],
+                }
+    print(f"ERROR: Metadata for DSID {dsid} and etag {etag} not found in campaign '{campaign}'")
+    return None
+
+
+def write_metadata_to_h5(h5_filename, metadata_dict):
+    with h5py.File(h5_filename, "a") as f:
+        meta_group = f.require_group("metadata")
+        for dsid_str, meta in metadata_dict.items():
+            dsid_group = meta_group.require_group(dsid_str)
+            for key in ["cross_section_pb", "genFiltEff", "kfactor"]:
+                if key in dsid_group:
+                    del dsid_group[key]
+                dsid_group.create_dataset(key, data=meta[key])
+
+
+def process_container_list(input_file, output_file, h5_merge_file=None):
+    result = {}
+    error_log = output_file.replace(".json", "_errors.log")
+    error_lines = []
+
+    print(f"Processing container list from file '{input_file}'")
+    with open(input_file) as f:
+        for line in f:
+            container = line.strip()
+            if not container:
+                continue
+            raw_campaign, campaign, dsid, etag = parse_line(container)
+            if not campaign or not dsid or not etag:
+                msg = f"[Skipped] Unable to parse container: {container}"
+                print(msg)
+                error_lines.append(msg)
+                continue
+            metadata = query_xsecdb(campaign, dsid, etag)
+            if metadata:
+                metadata["campaign"] = (
+                    f"{raw_campaign} (fallback to {campaign})"
+                    if raw_campaign != campaign
+                    else campaign
+                )
+                result[str(dsid)] = metadata
+            else:
+                msg = (
+                    f"ERROR: DSID {dsid} ({raw_campaign}) lookup failed, " f"container: {container}"
+                )
+                print(msg)
+                error_lines.append(msg)
+
+    print(f"Writing successful results to file '{output_file}'")
+    with open(output_file, "w") as out_f:
+        json.dump(result, out_f, indent=2)
+
+    if error_lines:
+        print(f"Writing error logs to file '{error_log}'")
+        with open(error_log, "w") as err_f:
+            for err in error_lines:
+                err_f.write(err + "\n")
+
+    if h5_merge_file:
+        print(f"Merging metadata into HDF5 file: {h5_merge_file}")
+        try:
+            write_metadata_to_h5(h5_merge_file, result)
+            print(f"Successfully merged metadata into {h5_merge_file}")
+        except (OSError, RuntimeError) as e:
+            print(f"ERROR during HDF5 merge: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Lookup cross-section metadata for containers " "and optionally merge into HDF5"
+    )
+    parser.add_argument(
+        "-i", "--input", required=True, help="Input txt file containing container names"
+    )
+    parser.add_argument("-o", "--output", default="metadata.json", help="Output JSON file name")
+    parser.add_argument(
+        "-m",
+        "--merge",
+        metavar="H5FILE",
+        help="If provided, merge the result into the specified HDF5 file",
+    )
+    args = parser.parse_args()
+
+    download_xsecdb_files()
+    process_container_list(args.input, args.output, args.merge)
+
+
+if __name__ == "__main__":
+    main()

--- a/ftag/find_metadata.py
+++ b/ftag/find_metadata.py
@@ -153,5 +153,5 @@ def main():
     process_container_list(args.input, args.output, args.merge)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/ftag/tests/test_find_metadata.py
+++ b/ftag/tests/test_find_metadata.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
 
-import h5py
-import pytest
+import json
+import sys
+import urllib.error
+from unittest.mock import patch
 
-from ftag.find_metadata import parse_line, query_xsecdb, write_metadata_to_h5
+import h5py
+import numpy as np
+import pytest
+from numpy.lib.recfunctions import unstructured_to_structured as u2s
+
+from ftag import find_metadata, mock
+from ftag.find_metadata import (
+    download_xsecdb_files,
+    main,
+    parse_line,
+    process_container_list,
+    query_xsecdb,
+    write_metadata_to_h5,
+)
 from ftag.mock import get_mock_file
 
+# ------------------------
 # parse_line() tests
+# ------------------------
 
 
 def test_parse_line_valid():
@@ -27,20 +44,60 @@ def test_parse_line_invalid():
     assert etag is None
 
 
+# ------------------------
 # query_xsecdb() tests
+# ------------------------
 
 
-@pytest.mark.parametrize("campaign", ["mc15", "mc16", "mc21", "mc23"])
-def test_query_xsecdb_missing_file(campaign):
-    # Ensure no file exists
-    result = query_xsecdb(campaign, 301200, "e5270")
+def test_query_xsecdb_missing_file():
+    with patch("ftag.find_metadata.Path.exists", return_value=False):
+        result = query_xsecdb("mc16", 301200, "e5270")
+        assert result is None
+
+
+def test_query_xsecdb_with_match(tmp_path):
+    fake_file = tmp_path / "PMGxsecDB_mc16.txt"
+    content = "301200 dummy 1.23 0.95 1.1 x y z e5270\n"
+    fake_file.write_text(content)
+
+    find_metadata.XSECDB_MAP["mc16"] = str(fake_file)
+
+    result = query_xsecdb("mc16", 301200, "e5270")
+    assert result is not None
+    assert result["cross_section_pb"] == pytest.approx(1.23)
+    assert result["genFiltEff"] == pytest.approx(0.95)
+    assert result["kfactor"] == pytest.approx(1.1)
+
+
+def test_query_xsecdb_no_match(tmp_path):
+    fake_file = tmp_path / "PMGxsecDB_mc16.txt"
+    fake_file.write_text("999999 dummy 1.0 1.0 1.0 x x x e1234\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(fake_file)
+    result = query_xsecdb("mc16", 301200, "e5270")
     assert result is None
 
 
-# write_metadata_to_h5() test using ftag.mock
+def test_query_xsecdb_bad_format(tmp_path):
+    fake_file = tmp_path / "PMGxsecDB_mc16.txt"
+    fake_file.write_text("bad line\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(fake_file)
+    result = query_xsecdb("mc16", 301200, "e5270")
+    assert result is None
 
 
-def test_write_metadata_to_h5_real_file():
+# ------------------------
+# write_metadata_to_h5() test using mock file
+# ------------------------
+
+
+@patch("ftag.mock.mock_jets")
+def test_write_metadata_to_h5_real_file(mock_mock_jets):
+    dummy_jets = u2s(
+        np.array([[1.0] * len(mock.JET_VARS)], dtype=np.float32).repeat(10, axis=0),
+        dtype=np.dtype(mock.JET_VARS),
+    )
+    mock_mock_jets.return_value = dummy_jets
+
     mock_path, h5file = get_mock_file(num_jets=10)
     h5file.close()  # Close for writing
 
@@ -61,3 +118,221 @@ def test_write_metadata_to_h5_real_file():
         assert dsid_group["cross_section_pb"][()] == pytest.approx(1.23)
         assert dsid_group["genFiltEff"][()] == pytest.approx(0.95)
         assert dsid_group["kfactor"][()] == pytest.approx(1.1)
+
+
+def test_write_metadata_to_h5_error():
+    with patch("ftag.find_metadata.h5py.File", side_effect=OSError("fail")), pytest.raises(
+        OSError, match="fail"
+    ):
+        write_metadata_to_h5(
+            "bad.h5",
+            {"123": {"cross_section_pb": 1.0, "genFiltEff": 1.0, "kfactor": 1.0}},
+        )
+
+
+# ------------------------
+# process_container_list() integration test
+# ------------------------
+
+
+def test_process_container_list_integration(tmp_path):
+    input_file = tmp_path / "containers.txt"
+    output_json = tmp_path / "output.json"
+    output_h5 = tmp_path / "output.h5"
+
+    input_file.write_text("mc16_13TeV.301200.Sherpa_ttbar.e5270_\n")
+
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    db_file.write_text("301200 dummy 1.23 0.95 1.1 x y z e5270\n")
+
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+
+    process_container_list(str(input_file), str(output_json), str(output_h5))
+
+    assert output_json.exists()
+    assert "301200" in output_json.read_text()
+
+    with h5py.File(output_h5, "r") as f:
+        assert "301200" in f["metadata"]
+
+
+def test_process_container_list_parse_fail(tmp_path):
+    input_file = tmp_path / "bad.txt"
+    output_json = tmp_path / "output.json"
+    input_file.write_text("invalid_container_name\n")
+    process_container_list(str(input_file), str(output_json))
+    assert output_json.exists()
+
+
+def test_process_container_list_query_fail(tmp_path):
+    input_file = tmp_path / "queryfail.txt"
+    output_json = tmp_path / "output.json"
+    input_file.write_text("mc16_13TeV.301200.Sherpa_ttbar.e5270_\n")
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    db_file.write_text("999999 dummy 1.0 1.0 1.0 x x x e1234\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+    process_container_list(str(input_file), str(output_json))
+    assert output_json.exists()
+
+
+def test_process_container_list_error_log(tmp_path):
+    input_file = tmp_path / "bad2.txt"
+    output_json = tmp_path / "metadata.json"
+    input_file.write_text("bad_container\n" "mc16_13TeV.301200.Sherpa_ttbar.e5270_")
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    db_file.write_text("999999 dummy 1.0 1.0 1.0 x x x e0000\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+    process_container_list(str(input_file), str(output_json))
+    assert (tmp_path / "metadata_errors.log").exists()
+
+
+# ------------------------
+# download_xsecdb_files() test
+# ------------------------
+
+
+def test_download_xsecdb_files():
+    with patch("ftag.find_metadata.Path.exists", return_value=False), patch(
+        "ftag.find_metadata.urllib.request.urlretrieve"
+    ) as mock_urlretrieve:
+        download_xsecdb_files()
+        assert mock_urlretrieve.call_count == 4
+
+
+def test_download_xsecdb_files_fail():
+    with patch("ftag.find_metadata.Path.exists", return_value=False), patch(
+        "ftag.find_metadata.urllib.request.urlretrieve",
+        side_effect=urllib.error.URLError("fail"),
+    ) as mock_urlretrieve:
+        download_xsecdb_files()
+        assert mock_urlretrieve.call_count == 4
+
+
+# ------------------------
+# CLI main() test
+# ------------------------
+
+
+def test_main_invokes_all(tmp_path, monkeypatch):
+    containers = tmp_path / "containers.txt"
+    containers.write_text("mc16_13TeV.301200.Sherpa_ttbar.e5270_\n")
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    db_file.write_text("301200 dummy 1.23 0.95 1.1 x y z e5270\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+
+    output_json = tmp_path / "result.json"
+    h5file = tmp_path / "merged.h5"
+
+    monkeypatch.setattr(
+        sys, "argv", ["script", "-i", str(containers), "-o", str(output_json), "-m", str(h5file)]
+    )
+    main()
+
+    assert output_json.exists()
+    with h5py.File(h5file) as f:
+        assert "metadata" in f
+        assert "301200" in f["metadata"]
+
+
+def test_query_xsecdb_print_not_found(tmp_path, capsys):
+    fake_file = tmp_path / "PMGxsecDB_mc16.txt"
+    fake_file.write_text("301200 dummy 1.0 1.0 1.0 x x x e1234\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(fake_file)
+    result = query_xsecdb("mc16", 301200, "e9999")
+    captured = capsys.readouterr()
+    assert "not found" in captured.out
+    assert result is None
+
+
+def test_write_metadata_to_h5_key_skip(tmp_path):
+    h5file = tmp_path / "file.h5"
+    with h5py.File(h5file, "w") as f:
+        g = f.create_group("metadata/123")
+        g.create_dataset("cross_section_pb", data=0.1)
+    meta = {"123": {"cross_section_pb": 0.2, "genFiltEff": 0.3, "kfactor": 0.4}}
+    write_metadata_to_h5(h5file, meta)
+    with h5py.File(h5file, "r") as f:
+        assert f["metadata/123/genFiltEff"][()] == pytest.approx(0.3)
+        assert f["metadata/123/kfactor"][()] == pytest.approx(0.4)
+
+
+def test_main_merge_fail(tmp_path, monkeypatch):
+    container = tmp_path / "c.txt"
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    container.write_text("mc16_13TeV.301200.Sherpa_ttbar.e5270_\n")
+    db_file.write_text("301200 dummy 1.0 1.0 1.0 x x x e5270\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+
+    out_json = tmp_path / "x.json"
+    out_h5 = tmp_path / "fail.h5"
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["script", "-i", str(container), "-o", str(out_json), "-m", str(out_h5)],
+    )
+
+    with patch("ftag.find_metadata.h5py.File", side_effect=RuntimeError("merge fail")):
+        main()
+
+
+def test_query_xsecdb_partial_match_but_etag_fail(tmp_path, capsys):
+    file = tmp_path / "PMGxsecDB_mc16.txt"
+    file.write_text("301200 dummy 1.0 1.0 1.0 x x x e1111\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(file)
+    query_xsecdb("mc16", 301200, "e9999")
+    captured = capsys.readouterr()
+    assert "not found" in captured.out
+
+
+def test_process_container_list_missing_metadata_log(tmp_path, capsys):
+    container_file = tmp_path / "missing.txt"
+    container_file.write_text("mc16_13TeV.301200.Sherpa_ttbar.e0000_\n")
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    db_file.write_text("999999 dummy 1.0 1.0 1.0 x x x e1234\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+    output_file = tmp_path / "meta.json"
+    process_container_list(str(container_file), str(output_file))
+    captured = capsys.readouterr()
+    assert "lookup failed" in captured.out
+
+
+def test_main_no_merge(monkeypatch, tmp_path):
+    container_file = tmp_path / "c.txt"
+    out_json = tmp_path / "o.json"
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    container_file.write_text("mc16_13TeV.301200.Sherpa_ttbar.e5270_\n")
+    db_file.write_text("301200 dummy 1.23 0.95 1.1 x y z e5270\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+    monkeypatch.setattr(sys, "argv", ["script", "-i", str(container_file), "-o", str(out_json)])
+    main()
+    assert out_json.exists()
+
+
+def test_query_xsecdb_skip_comment_line(tmp_path):
+    # Create a database file with a comment line
+    fake_file = tmp_path / "PMGxsecDB_mc16.txt"
+    fake_file.write_text("# this is a comment line\n301200 dummy 1.2 0.9 1.1 x x x e5270\n")
+
+    # Override the db path
+    find_metadata.XSECDB_MAP["mc16"] = str(fake_file)
+
+    # Query existing data (should skip the comment and match)
+    result = query_xsecdb("mc16", 301200, "e5270")
+    assert result is not None
+    assert result["cross_section_pb"] == pytest.approx(1.2)
+
+
+def test_process_container_list_skips_empty_line(tmp_path):
+    input_file = tmp_path / "containers.txt"
+    output_file = tmp_path / "meta.json"
+    input_file.write_text("\nmc16_13TeV.301200.Sherpa_ttbar.e5270_\n")
+
+    db_file = tmp_path / "PMGxsecDB_mc16.txt"
+    db_file.write_text("301200 dummy 1.0 1.0 1.0 x x x e5270\n")
+    find_metadata.XSECDB_MAP["mc16"] = str(db_file)
+
+    process_container_list(str(input_file), str(output_file))
+    assert output_file.exists()
+    content = json.loads(output_file.read_text())
+    assert "301200" in content

--- a/ftag/tests/test_find_metadata.py
+++ b/ftag/tests/test_find_metadata.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import h5py
+import pytest
+
+from ftag.find_metadata import parse_line, query_xsecdb, write_metadata_to_h5
+from ftag.mock import get_mock_file
+
+# parse_line() tests
+
+
+def test_parse_line_valid():
+    container = "mc16_13TeV.301200.Sherpa_ttbar.e5270_"
+    raw_campaign, campaign, dsid, etag = parse_line(container)
+    assert raw_campaign == "mc16"
+    assert campaign == "mc16"
+    assert dsid == 301200
+    assert etag == "e5270"
+
+
+def test_parse_line_invalid():
+    container = "invalid_container_name"
+    raw_campaign, campaign, dsid, etag = parse_line(container)
+    assert raw_campaign is None
+    assert campaign is None
+    assert dsid is None
+    assert etag is None
+
+
+# query_xsecdb() tests
+
+
+@pytest.mark.parametrize("campaign", ["mc15", "mc16", "mc21", "mc23"])
+def test_query_xsecdb_missing_file(campaign):
+    # Ensure no file exists
+    result = query_xsecdb(campaign, 301200, "e5270")
+    assert result is None
+
+
+# write_metadata_to_h5() test using ftag.mock
+
+
+def test_write_metadata_to_h5_real_file():
+    mock_path, h5file = get_mock_file(num_jets=10)
+    h5file.close()  # Close for writing
+
+    fake_metadata = {
+        "301200": {
+            "cross_section_pb": 1.23,
+            "genFiltEff": 0.95,
+            "kfactor": 1.1,
+        }
+    }
+
+    write_metadata_to_h5(mock_path, fake_metadata)
+
+    with h5py.File(mock_path, "r") as f:
+        assert "metadata" in f
+        assert "301200" in f["metadata"]
+        dsid_group = f["metadata"]["301200"]
+        assert dsid_group["cross_section_pb"][()] == pytest.approx(1.23)
+        assert dsid_group["genFiltEff"][()] == pytest.approx(0.95)
+        assert dsid_group["kfactor"][()] == pytest.approx(1.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ wps = "ftag.working_points:main"
 h5move = "ftag.hdf5.h5move:main"
 h5split = "ftag.hdf5.h5split:main"
 h5addcol = "ftag.hdf5.h5add_col:main"
+find_metadata = "ftag.find_metadata:main"
 
 [tool.setuptools]
 packages = ["ftag", "ftag.hdf5", "ftag.utils"]


### PR DESCRIPTION
## Summary

find_metadata.py

Injects metadata (cross_section_pb, genFiltEff, kfactor) into .h5 files produced by TDD.

See also discussion for where to place this script in the training workflow: https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-dataset-dumper/-/merge_requests/881

Usage:
    python find_metadata.py <h5_file1> [<h5_file2> ...] [-m fallback.yaml]

Modes:

    1. Auto mode (default):
        - Extract ATLAS BigPanDA Task ID from filename
        - Query BigPanDA → extract task info → parse DSID/etag/campaign
        - Query PMGxsecDB and write metadata into /metadata/<DSID>/ in the .h5 file

    2. Fallback mode (-m):
        - If auto lookup fails, use a YAML file to inject metadata manually
        - YAML must contain exactly one entry (see example_metadata.yaml)

Example:
    python find_metadata.py user.username.taskid._000001.h5
    python find_metadata.py localdump.h5 -m fallback.yaml

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
