### PR TITLE
feat: Modified calculate_efficiency to have rejection 1.0 at efficien…

### DIFF
--- a/ftag/utils/metrics.py
+++ b/ftag/utils/metrics.py
@@ -172,6 +172,13 @@ def calculate_efficiency(
     # Get the cutvalue for the given target efficiency
     cutvalue = weighted_percentile(arr=sig_disc, percentile=1.0 - target_eff, weights=sig_weights)
 
+    # Get the minimum discriminant for the background
+    cutvalue_eff_1 = weighted_percentile(arr=bkg_disc, percentile=0.0, weights=sig_weights)
+
+    # Get the position where the target efficiency equals 1 and replace the cutvalue
+    target_eff_1_mask = target_eff == 1.0
+    cutvalue[target_eff_1_mask] = cutvalue_eff_1
+
     # Sort the cutvalues to get the correct order
     sorted_args = np.argsort(1 - target_eff)
 


### PR DESCRIPTION
…cy 1.0.

## Summary

This pull request introduces the following changes

* Change the cut-value relative to the first bin from the minimum of the signal discriminant distribution to the background's minimum.

Relates to the following issues

* With the present definition of calculate_efficiency some background events can escape the first cutvalue, so that the background efficiency obtained is < 1 and the relative rejection is > 1. With this change the ROC curves are now forced to finish at the point (1,1).

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
