### PR TITLE
Fix h5 reader/writer/utils to work for files which have groups

### DIFF
--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -115,7 +115,7 @@ def get_shape(num_jets: int, batch: dict[str, np.ndarray]) -> dict[str, tuple[in
     return shape
 
 
-def get_all_groups(file: Path | str) -> dict[str, None]:
+def get_all_datasets(file: Path | str) -> dict[str, None]:
     """Returns a dictionary with all the groups in the h5 file.
 
     Parameters
@@ -126,12 +126,12 @@ def get_all_groups(file: Path | str) -> dict[str, None]:
     Returns
     -------
     dict[str, None]
-        A dictionary with all the groups in the h5 file as keys and None as values,
+        A dictionary with all the datasets in the h5 file as keys and None as values,
         such that h5read.stream(all_groups) will return all the groups in the file.
     """
     with h5py.File(file, "r") as f:
-        groups = list(f.keys())
-        return dict.fromkeys(groups)
+        datasets = [d for d in f if isinstance(f[d], h5py.Dataset)]
+        return dict.fromkeys(datasets)
 
 
 def h5_add_column(
@@ -223,7 +223,7 @@ def h5_add_column(
     writer = None
 
     input_variables = (
-        get_all_groups(input_file) if input_groups is None else dict.fromkeys(input_groups)
+        get_all_datasets(input_file) if input_groups is None else dict.fromkeys(input_groups)
     )
     if output_groups is None:
         output_groups = list(input_variables.keys())

--- a/ftag/hdf5/h5split.py
+++ b/ftag/hdf5/h5split.py
@@ -47,7 +47,7 @@ def main(args=None):
     print(f"\nSplitting: {src}")
     print(f"Destination: {dst}")
     with h5py.File(src, "r") as f:
-        total_jets = next(iter(f.values())).shape[0]
+        total_jets = next(d.shape[0] for d in f.values() if isinstance(d, h5py.Dataset))
 
     num_full_files = total_jets // jets_per_file
     remainder = total_jets % jets_per_file

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -9,6 +9,62 @@ import numpy as np
 import ftag
 
 
+def write_group_full(h5group: h5py.Group, data: dict):
+    # Write group-level attributes
+    if "_group_attrs" in data:
+        for k, v in data["_group_attrs"].items():
+            h5group.attrs[k] = v
+
+    for key, value in data.items():
+        if key == "_group_attrs":
+            continue
+        if isinstance(value, dict) and "data" in value:
+            dset = h5group.create_dataset(key, data=value["data"])
+            for attr_k, attr_v in value["attrs"].items():
+                dset.attrs[attr_k] = attr_v
+        elif isinstance(value, dict):
+            subgroup = h5group.create_group(key)
+            write_group_full(subgroup, value)
+        else:
+            raise TypeError(f"Unexpected value type for key '{key}': {type(value)}")
+
+
+def extract_group_full(group: h5py.Group) -> dict:
+    result = {}
+    # Save group-level attributes
+    if group.attrs:
+        result["_group_attrs"] = {k: group.attrs[k] for k in group.attrs}
+    for key, item in group.items():
+        if isinstance(item, h5py.Dataset):
+            result[key] = {"data": item[()], "attrs": {k: item.attrs[k] for k in item.attrs}}
+        elif isinstance(item, h5py.Group):
+            result[key] = extract_group_full(item)
+        else:
+            raise TypeError(f"Unsupported item {key}: {type(item)}")
+    return result
+
+
+def extract_group(group: h5py.Group) -> dict:
+    data = {}
+    for key, item in group.items():
+        if isinstance(item, h5py.Dataset):
+            data[key] = item[()]  # Convert to NumPy array
+        elif isinstance(item, h5py.Group):
+            data[key] = extract_group(item)  # Recursive
+        else:
+            raise TypeError(f"Unsupported HDF5 item type: {type(item)}")
+    return data
+
+
+def write_group(h5file: h5py.Group, data: dict):
+    for key, value in data.items():
+        if isinstance(value, dict):
+            subgroup = h5file.create_group(key)
+            write_group(subgroup, value)  # Recursive
+        else:
+            h5file.create_dataset(key, data=value)
+
+
 @dataclass
 class H5Writer:
     """Writes jets to an HDF5 file.
@@ -35,7 +91,8 @@ class H5Writer:
         Whether to shuffle the jets before writing. Default is True.
     num_jets : int | None
         Number of jets to write.
-
+    groups: dict[str, h5py.Group] | None
+        Groups to copy from the source file. Default is None.
     """
 
     dst: Path | str
@@ -48,6 +105,7 @@ class H5Writer:
     full_precision_vars: list[str] | None = None
     shuffle: bool = True
     num_jets: int | None = None  # Allow dynamic mode by defaulting to None
+    groups: dict[str, h5py.Group] | None = None  # Groups to copy from source file
 
     def __post_init__(self):
         self.num_written = 0
@@ -79,14 +137,30 @@ class H5Writer:
 
         for name, dtype in self.dtypes.items():
             self.create_ds(name, dtype)
+        if self.groups:
+            self.save_groups(self.groups)
 
     @classmethod
     def from_file(
-        cls, source: Path, num_jets: int | None = 0, variables=None, **kwargs
+        cls, source: Path, num_jets: int | None = 0, variables=None, copy_groups=True, **kwargs
     ) -> H5Writer:
         with h5py.File(source, "r") as f:
-            dtypes = {name: ds.dtype for name, ds in f.items()}
-            shapes = {name: ds.shape for name, ds in f.items()}
+            dtypes = {}
+            shapes = {}
+            compression = []
+            groups = {}
+            for name, ds in f.items():
+                if isinstance(ds, h5py.Group):
+                    if copy_groups:
+                        groups[name] = extract_group_full(ds)
+                    continue
+                if not isinstance(ds, h5py.Dataset):
+                    raise TypeError(
+                        f"Unsupported type {type(ds)} for dataset {name} in file {source}"
+                    )
+                dtypes[name] = ds.dtype
+                shapes[name] = ds.shape
+                compression.append(ds.compression)
 
             if variables:
                 new_dtye = {}
@@ -105,12 +179,17 @@ class H5Writer:
                 shapes = new_shape
             if num_jets != 0:
                 shapes = {name: (num_jets,) + shape[1:] for name, shape in shapes.items()}
-            compression = [ds.compression for ds in f.values()]
+
             assert len(set(compression)) == 1, "Must have same compression for all groups"
             compression = compression[0]
             if "compression" not in kwargs:
                 kwargs["compression"] = compression
-        return cls(dtypes=dtypes, shapes=shapes, **kwargs)
+        return cls(dtypes=dtypes, shapes=shapes, groups=groups, **kwargs)
+
+    def save_groups(self, groups: dict[str, dict]) -> None:
+        for name, group_data in groups.items():
+            if name not in self.file:
+                write_group_full(self.file.create_group(name), group_data)
 
     def create_ds(self, name: str, dtype: np.dtype) -> None:
         if name == self.jets_name and self.add_flavour_label and "flavour_label" not in dtype.names:

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -187,5 +187,6 @@ def get_mock_file(
     if tracks_name:
         tracks = mock_tracks(num_jets, num_tracks)
         f.create_dataset(tracks_name, data=tracks)
-
+    # Add some dummy meta-data
+    f.create_dataset("cutBookkeeper/nominal/counts", data=np.array([100, 200, 300]))
     return fname, f

--- a/ftag/tests/hdf5/test_h5add_col.py
+++ b/ftag/tests/hdf5/test_h5add_col.py
@@ -10,7 +10,7 @@ import pytest
 
 from ftag import get_mock_file
 from ftag.hdf5.h5add_col import (
-    get_all_groups,
+    get_all_datasets,
     get_shape,
     h5_add_column,
     merge_dicts,
@@ -63,8 +63,8 @@ def test_get_shape_scalar_and_vector():
     assert shape["b"] == (100, 3)
 
 
-def test_get_all_groups(input_file):
-    groups = get_all_groups(input_file)
+def test_get_all_datasets(input_file):
+    groups = get_all_datasets(input_file)
     assert isinstance(groups, dict)
     assert "jets" in groups
 

--- a/ftag/tests/hdf5/test_h5split.py
+++ b/ftag/tests/hdf5/test_h5split.py
@@ -7,6 +7,7 @@ import pytest
 
 from ftag import get_mock_file
 from ftag.hdf5.h5split import main, parse_args
+from ftag.hdf5.h5utils import compare_groups
 
 
 # Define a fixture to provide mock data
@@ -43,7 +44,10 @@ def test_main(mock_h5_file, capsys):
         with h5py.File(f) as dst, h5py.File(mock_h5_file) as src:
             assert src.keys() == dst.keys()
             for k in src:
-                assert (src[k][start:stop] == dst[k]).all()
+                if isinstance(src[k], h5py.Dataset):
+                    assert (src[k][start:stop] == dst[k]).all()
+                else:
+                    compare_groups(src[k], dst[k], path=k)
 
 
 def test_remainder(mock_h5_file, capsys):
@@ -67,7 +71,10 @@ def test_remainder(mock_h5_file, capsys):
         with h5py.File(f) as dst, h5py.File(mock_h5_file) as src:
             assert src.keys() == dst.keys()
             for k in src:
-                assert (src[k][start:stop] == dst[k]).all()
+                if isinstance(src[k], h5py.Dataset):
+                    assert (src[k][start:stop] == dst[k]).all()
+                else:
+                    compare_groups(src[k], dst[k], path=k)
 
 
 def test_attrs(mock_h5_file):


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Modifies readers/writers to no longer assume that all containers in an h5 file are datasets, and instead allows groups
* We assume the groups just hold meta-data, and do not need to be copied over row-by-row or in batches

Relates to the following issues

* !140
*

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
