### PR TITLE
Adding `cut_value` Option for `calculate_efficiency` and `calculate_rejection` Functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Adding `cut_value` Option for `calculate_efficiency` and `calculate_rejection` Functions [#144](https://github.com/umami-hep/atlas-ftag-tools/pull/144)
 - Enabling Docstring Checks [#143](https://github.com/umami-hep/atlas-ftag-tools/pull/143)
 
 ### [v0.2.15](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.2.15) (07.08.2025)

--- a/ftag/tests/utils/test_metrics.py
+++ b/ftag/tests/utils/test_metrics.py
@@ -111,8 +111,8 @@ class CalcEffTestCase(unittest.TestCase):
         #       from μ+2o to infinity --> expect a value of 0.0227501
         # https://www.wolframalpha.com/input?i=integrate+1%2Fsqrt%282+pi%29+*+exp%28-0.5*x**2%29+from+2+to+oo
         bkg_eff, cut = calculate_efficiency(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=0.841345,
             return_cuts=True,
         )
@@ -123,8 +123,8 @@ class CalcEffTestCase(unittest.TestCase):
 
         # Test without returned cut values
         bkg_eff = calculate_efficiency(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=0.841345,
             return_cuts=False,
         )
@@ -135,8 +135,8 @@ class CalcEffTestCase(unittest.TestCase):
         # explanation is the same as above, now also cut the signal in the middle
         # --> target sig.efficiency 0.841345 and 0.5 --> cut at 2 and 3
         bkg_eff, cut = calculate_efficiency(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=[0.841345, 0.5],
             return_cuts=True,
         )
@@ -144,6 +144,60 @@ class CalcEffTestCase(unittest.TestCase):
         # since we use random numbers
         np.testing.assert_array_almost_equal(cut, np.array([1.9956997, 2.990996]))
         np.testing.assert_array_almost_equal(bkg_eff, np.array([0.02367, 0.00144]))
+
+    def test_float_cut_value(self):
+        """Test efficiency and cut value calculation for one cut value."""
+        bkg_eff, cut = calculate_efficiency(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=1.9956997,
+            return_cuts=True,
+        )
+        # the values here differ slightly from the values of the analytical integral,
+        # since we use random numbers
+        self.assertAlmostEqual(cut, 1.9956997)
+        self.assertAlmostEqual(bkg_eff, 0.02367)
+
+        # Test without returned cut values
+        bkg_eff = calculate_efficiency(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=1.9956997,
+            return_cuts=False,
+        )
+        self.assertAlmostEqual(bkg_eff, 0.02367)
+
+    def test_array_cut_value(self):
+        """Test efficiency and cut value calculation for list of cut values."""
+        bkg_eff, cut = calculate_efficiency(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=[1.9956997, 2.990996],
+            return_cuts=True,
+        )
+        # the values here differ slightly from the values of the analytical integral,
+        # since we use random numbers
+        np.testing.assert_array_almost_equal(cut, np.array([1.9956997, 2.990996]))
+        np.testing.assert_array_almost_equal(bkg_eff, np.array([0.02367, 0.00144]))
+
+    def test_both_cut_value_and_target_eff(self):
+        """Test the ValueError if both cut_value and target_eff are defined or None."""
+        with self.assertRaises(ValueError):
+            calculate_efficiency(
+                sig_disc=self.disc_sig,
+                bkg_disc=self.disc_bkg,
+                target_eff=[0.841345, 0.5],
+                cut_value=[1, 3],
+                return_cuts=True,
+            )
+        with self.assertRaises(ValueError):
+            calculate_efficiency(
+                sig_disc=self.disc_sig,
+                bkg_disc=self.disc_bkg,
+                target_eff=None,
+                cut_value=None,
+                return_cuts=True,
+            )
 
 
 class CalcRejTestCase(unittest.TestCase):
@@ -158,8 +212,8 @@ class CalcRejTestCase(unittest.TestCase):
         """Test efficiency and cut value calculation for one target value."""
         # Same as for eff but this time for rejection, just use rej = 1 / eff
         bkg_rej, cut = calculate_rejection(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=0.841345,
             return_cuts=True,
         )
@@ -168,8 +222,8 @@ class CalcRejTestCase(unittest.TestCase):
 
         # Test without returned cut values
         bkg_rej = calculate_rejection(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=0.841345,
             return_cuts=False,
         )
@@ -180,8 +234,8 @@ class CalcRejTestCase(unittest.TestCase):
         # explanation is the same as above, now also cut the signal in the middle
         # --> target sig.efficiency 0.841345 and 0.5 --> cut at 2 and 3
         bkg_rej, cut = calculate_rejection(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=[0.841345, 0.5],
             return_cuts=True,
         )
@@ -191,14 +245,76 @@ class CalcRejTestCase(unittest.TestCase):
     def test_with_smooth(self):
         """Test efficiency and cut value calculation with smoothing."""
         bkg_rej, cut = calculate_rejection(
-            self.disc_sig,
-            self.disc_bkg,
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
             target_eff=[0.841345, 0.5],
             return_cuts=True,
             smooth=True,
         )
         np.testing.assert_array_almost_equal(cut, np.array([1.9956997, 2.990996]))
         np.testing.assert_array_almost_equal(bkg_rej, np.array([237.052272, 499.639743]))
+
+    def test_float_cut_value(self):
+        """Test efficiency and cut value calculation for one cut value."""
+        bkg_rej, cut = calculate_rejection(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=1.9956997,
+            return_cuts=True,
+        )
+        self.assertAlmostEqual(cut, 1.9956997)
+        self.assertAlmostEqual(bkg_rej, 1 / 0.02367)
+
+        # Test without returned cut values
+        bkg_rej = calculate_rejection(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=1.9956997,
+            return_cuts=False,
+        )
+        self.assertAlmostEqual(bkg_rej, 1 / 0.02367)
+
+    def test_array_cut_value(self):
+        """Test efficiency and cut value calculation for list of cut_values."""
+        bkg_rej, cut = calculate_rejection(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=[1.9956997, 2.990996],
+            return_cuts=True,
+        )
+        np.testing.assert_array_almost_equal(cut, np.array([1.9956997, 2.990996]))
+        np.testing.assert_array_almost_equal(bkg_rej, 1 / np.array([0.02367, 0.00144]))
+
+    def test_with_smooth_cut_value(self):
+        """Test efficiency and cut value calculation with smoothing."""
+        bkg_rej, cut = calculate_rejection(
+            sig_disc=self.disc_sig,
+            bkg_disc=self.disc_bkg,
+            cut_value=[1.9956997, 2.990996],
+            return_cuts=True,
+            smooth=True,
+        )
+        np.testing.assert_array_almost_equal(cut, np.array([1.9956997, 2.990996]))
+        np.testing.assert_array_almost_equal(bkg_rej, np.array([237.052272, 499.639743]))
+
+    def test_both_cut_value_and_target_eff(self):
+        """Test the ValueError if both cut_value and target_eff are defined or None."""
+        with self.assertRaises(ValueError):
+            calculate_rejection(
+                sig_disc=self.disc_sig,
+                bkg_disc=self.disc_bkg,
+                target_eff=[0.841345, 0.5],
+                cut_value=[1, 3],
+                return_cuts=True,
+            )
+        with self.assertRaises(ValueError):
+            calculate_rejection(
+                sig_disc=self.disc_sig,
+                bkg_disc=self.disc_bkg,
+                target_eff=None,
+                cut_value=None,
+                return_cuts=True,
+            )
 
 
 class EffErrTestCase(unittest.TestCase):

--- a/ftag/utils/metrics.py
+++ b/ftag/utils/metrics.py
@@ -120,7 +120,8 @@ def weighted_percentile(
 def calculate_efficiency(
     sig_disc: np.ndarray,
     bkg_disc: np.ndarray,
-    target_eff: float | list | np.ndarray,
+    target_eff: float | list | np.ndarray | None = None,
+    cut_value: float | list | np.ndarray | None = None,
     return_cuts: bool = False,
     sig_weights: np.ndarray = None,
     bkg_weights: np.ndarray = None,
@@ -133,8 +134,11 @@ def calculate_efficiency(
         Signal discriminant
     bkg_disc : np.ndarray
         Background discriminant
-    target_eff : float | list | np.ndarray
-        Working point which is used for discriminant calculation
+    target_eff : float | list | np.ndarray | None, optional
+        Working point which is used for discriminant calculation. By default None
+    cut_value : float | list | np.ndarray | None, optional
+        Instead of the working points being calculated on the sample, you can give
+        provide the cut values directly. By default None
     return_cuts : bool
         Specifies if the cut values corresponding to the provided WPs are returned.
         If target_eff is a float, only one cut value will be returned. If target_eff
@@ -149,9 +153,14 @@ def calculate_efficiency(
     eff : float or np.ndarray
         Efficiency.
         Return float if target_eff is a float, else np.ndarray
-    cutvalue : float or np.ndarray
+    cut_vals : float or np.ndarray
         Cutvalue if return_cuts is True.
         Return float if target_eff is a float, else np.ndarray
+
+    Raises
+    ------
+    ValueError
+        If target_eff and cut_value are both not None or both are None
     """
     logger.debug("Calculating efficiency.")
     logger.debug("sig_disc: %s", sig_disc)
@@ -161,22 +170,37 @@ def calculate_efficiency(
     logger.debug("sig_weights: %s", sig_weights)
     logger.debug("bkg_weights: %s", bkg_weights)
 
+    if (target_eff is None) == (cut_value is None):
+        raise ValueError("Either target_eff or cut_value must/can be defined!")
+
     # float | np.ndarray for both target_eff and the returned values
     return_float = False
     if isinstance(target_eff, float):
         return_float = True
 
-    # Flatten the target efficiencies
-    target_eff = np.asarray([target_eff]).flatten()
+    # Calculate the cut_vals based on the target_eff
+    if target_eff is not None:
+        # Flatten the target efficiencies
+        target_eff = np.asarray([target_eff]).flatten()
 
-    # Get the cutvalue for the given target efficiency
-    cutvalue = weighted_percentile(arr=sig_disc, percentile=1.0 - target_eff, weights=sig_weights)
+        # Get the cut_vals for the given target efficiency
+        cut_vals = weighted_percentile(
+            arr=sig_disc, percentile=1.0 - target_eff, weights=sig_weights
+        )
 
-    # Sort the cutvalues to get the correct order
-    sorted_args = np.argsort(1 - target_eff)
+        # Sort the cut_vals to get the correct order
+        sorted_args = np.argsort(1 - target_eff)
+
+    # If the cut values are provided, use them
+    else:
+        cut_vals = np.asarray([cut_value]).flatten()
+
+        # Sort the cut_vals to get the correct order
+        sorted_args = np.argsort(cut_vals)
 
     # Get the histogram for the backgrounds
-    hist, _ = np.histogram(bkg_disc, (-np.inf, *cutvalue[sorted_args], np.inf), weights=bkg_weights)
+    logger.error((-np.inf, *cut_vals[sorted_args], np.inf))
+    hist, _ = np.histogram(bkg_disc, (-np.inf, *cut_vals[sorted_args], np.inf), weights=bkg_weights)
 
     # Calculate the efficiencies for the calculated cut values
     eff = hist[::-1].cumsum()[-2::-1] / hist.sum()
@@ -185,11 +209,11 @@ def calculate_efficiency(
     # Ensure that a float is returned if float was given
     if return_float:
         eff = eff[0]
-        cutvalue = cutvalue[0]
+        cut_vals = cut_vals[0]
 
     # Also return the cuts if wanted
     if return_cuts:
-        return eff, cutvalue
+        return eff, cut_vals
 
     return eff
 
@@ -197,7 +221,8 @@ def calculate_efficiency(
 def calculate_rejection(
     sig_disc: np.ndarray,
     bkg_disc: np.ndarray,
-    target_eff: float | list,
+    target_eff: float | list | None = None,
+    cut_value: float | list | None = None,
     return_cuts: bool = False,
     sig_weights: np.ndarray = None,
     bkg_weights: np.ndarray = None,
@@ -211,8 +236,11 @@ def calculate_rejection(
         Signal discriminant
     bkg_disc : np.ndarray
         Background discriminant
-    target_eff : float | list
-        Working point which is used for discriminant calculation
+    target_eff : float | list | None, optional
+        Working point which is used for discriminant calculation. By default None
+    cut_value : float | list | None, optional
+        Instead of the working points being calculated on the sample, you can give
+        provide the cut values directly. By default None
     return_cuts : bool, optional
         Specifies if the cut values corresponding to the provided WPs are returned.
         If target_eff is a float, only one cut value will be returned. If target_eff
@@ -232,6 +260,11 @@ def calculate_rejection(
     cut_value : float or np.ndarray
         Cutvalue if return_cuts is True.
         If target_eff is a float, a float is returned if it's a list a np.ndarray
+
+    Raises
+    ------
+    ValueError
+        If target_eff and cut_value are both not None or both are None
     """
     logger.debug("Calculating rejection.")
     logger.debug("sig_disc: %s", sig_disc)
@@ -242,11 +275,15 @@ def calculate_rejection(
     logger.debug("bkg_weights: %s", bkg_weights)
     logger.debug("smooth: %s", smooth)
 
+    if (target_eff is None) == (cut_value is None):
+        raise ValueError("Either target_eff or cut_value must/can be defined!")
+
     # Calculate the efficiency
     eff = calculate_efficiency(
         sig_disc=sig_disc,
         bkg_disc=bkg_disc,
         target_eff=target_eff,
+        cut_value=cut_value,
         return_cuts=return_cuts,
         sig_weights=sig_weights,
         bkg_weights=bkg_weights,

--- a/ftag/utils/metrics.py
+++ b/ftag/utils/metrics.py
@@ -199,7 +199,6 @@ def calculate_efficiency(
         sorted_args = np.argsort(cut_vals)
 
     # Get the histogram for the backgrounds
-    logger.error((-np.inf, *cut_vals[sorted_args], np.inf))
     hist, _ = np.histogram(bkg_disc, (-np.inf, *cut_vals[sorted_args], np.inf), weights=bkg_weights)
 
     # Calculate the efficiencies for the calculated cut values


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adding new functionality `cut_value` to `calculate_efficiency` and `calculate_rejection`

Tagging @AMHermansen

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
