### PR TITLE
Adding LZ4 to H5Writer as Default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
+
 ### [v0.3.1](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.1) (19.02.2026)
 
 - Make vds creation directory configurable when using wildcard [#148](https://github.com/umami-hep/atlas-ftag-tools/pull/148)

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### [Latest]
 
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
+
 ### [v0.3.2](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.2) (25.02.2026)
 
 - Fix MacOS test, use proper tempdir path [#149](https://github.com/umami-hep/atlas-ftag-tools/pull/149)

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -184,11 +184,7 @@ class H5Writer:
 
         elif compression == "lz4":
             used_opts = None
-            if self.compression_opts is None:
-                used_compression = hdf5plugin.LZ4()
-
-            else:
-                used_compression = hdf5plugin.LZ4(clevel=self.compression_opts)
+            used_compression = hdf5plugin.LZ4()
 
         elif compression == "zstd":
             used_opts = None

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import h5py
 import hdf5plugin
@@ -13,32 +14,68 @@ from ftag.hdf5.h5utils import extract_group_full, write_group_full
 
 @dataclass
 class H5Writer:
-    """Writes jets to an HDF5 file.
+    """Write jet-based data to an HDF5 file.
+
+    This class creates one dataset per entry in ``dtypes``/``shapes`` and
+    supports both fixed-size and dynamically growing output files. Floating-point
+    fields can optionally be downcast before writing, selected metadata groups
+    can be copied from an existing file, and several HDF5 compression backends
+    are supported.
 
     Attributes
     ----------
     dst : Path | str
         Path to the output file.
     dtypes : dict[str, np.dtype]
-        Dictionary of group names and their corresponding dtypes.
-    shapes : dict[str, tuple[int, ...]], optional
-        Dictionary of group names and their corresponding shapes.
+        Mapping from dataset name to output dtype.
+    shapes : dict[str, tuple[int, ...]]
+        Mapping from dataset name to output shape. All datasets must agree in
+        their first dimension unless ``num_jets`` is explicitly given.
     jets_name : str, optional
-        Name of the jets group. Default is "jets".
+        Name of the jet dataset. This dataset is used to determine batch sizes
+        during writing. Default is ``"jets"``.
     add_flavour_label : bool, optional
-        Whether to add a flavour label to the jets group. Default is False.
+        If ``True``, append a ``"flavour_label"`` field of type ``i4`` to the
+        jet dataset if it is not already present. Default is ``False``.
     compression : str | None, optional
-        Compression algorithm to use. Default is lz4.
-    precision : str, optional
-        Precision to use. Default is None.
+        Compression algorithm to use. Supported values are ``None``,
+        ``"none"``, ``"gzip"``, ``"lzf"``, ``"lz4"``, and ``"zstd"``.
+        Default is ``"lz4"``.
+    compression_opts : int | None, optional
+        Optional compression level or backend-specific compression setting.
+        For ``"gzip"``, this is passed as ``compression_opts`` to HDF5.
+        For plugin-based compressors such as ``"lz4"`` and ``"zstd"``, this is
+        interpreted as the plugin compression level and folded into the filter
+        object. Ignored for compressors that do not support an explicit level.
+        Default is ``None``.
+    precision : str | None, optional
+        Floating-point storage precision for output fields. Supported values are
+
+        - ``"full"``: cast floating-point fields to ``np.float32``
+        - ``"half"``: cast floating-point fields to ``np.float16``
+        - ``None``: keep original floating-point dtypes
+
+        Default is ``"full"``.
     full_precision_vars : list[str] | None, optional
-        List of variables to store in full precision. Default is None.
+        Variables that should keep their original dtype even when ``precision``
+        requests downcasting. Default is ``None``.
     shuffle : bool, optional
-        Whether to shuffle the jets before writing. Default is True.
-    num_jets : int | None
-        Number of jets to write.
-    groups: dict[str, h5py.Group] | None
-        Groups to copy from the source file. Default is None.
+        If ``True``, shuffle each batch before writing. Default is ``True``.
+    num_jets : int | None, optional
+        Expected total number of jets to write. If given, datasets are created
+        in fixed-size mode. If ``None``, datasets are created in dynamic mode
+        and resized during writing. Default is ``None``.
+    groups : dict[str, dict] | None, optional
+        Mapping of metadata group names to extracted group contents to be copied
+        into the output file. Default is ``None``.
+
+    Raises
+    ------
+    ValueError
+        If an unsupported precision or compression setting is provided.
+    AssertionError
+        If dataset shapes disagree in their first dimension when ``num_jets``
+        is not explicitly specified.
     """
 
     dst: Path | str
@@ -47,13 +84,14 @@ class H5Writer:
     jets_name: str = "jets"
     add_flavour_label: bool = False
     compression: str | None = "lz4"
+    compression_opts: int | None = None
     precision: str = "full"
     full_precision_vars: list[str] | None = None
     shuffle: bool = True
-    num_jets: int | None = None  # Allow dynamic mode by defaulting to None
-    groups: dict[str, h5py.Group] | None = None  # Groups to copy from source file
+    num_jets: int | None = None
+    groups: dict[str, dict] | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.num_written = 0
         self.rng = np.random.default_rng(42)
 
@@ -76,8 +114,7 @@ class H5Writer:
         else:
             raise ValueError(f"Invalid precision: {self.precision}")
 
-        # Check compression
-        self.compression = self._resolve_compression(self.compression)
+        self.compression, self.compression_opts = self._resolve_compression(self.compression)
 
         self.dst = Path(self.dst)
         self.dst.parent.mkdir(parents=True, exist_ok=True)
@@ -89,14 +126,19 @@ class H5Writer:
         if self.groups:
             self.save_groups(self.groups)
 
-    def _resolve_compression(self, compression: str | None) -> str | object | None:
-        """Resolve a user-facing compression string into an HDF5 compression spec.
+    def _resolve_compression(
+        self, compression: str | None
+    ) -> tuple[str | object | None, int | None]:
+        """Resolve a user-facing compression setting into HDF5 write arguments.
 
         This method converts a human-readable compression identifier into the
-        corresponding object or string expected by :func:`h5py.File.create_dataset`.
-        Built-in HDF5 filters (e.g. ``"gzip"``, ``"lzf"``) are returned unchanged,
-        while plugin-based filters (e.g. ``"lz4"``, ``"zstd"``) are converted into
-        the appropriate filter objects provided by ``hdf5plugin``.
+        values used when calling :meth:`h5py.File.create_dataset`. Built-in HDF5
+        filters such as ``"gzip"`` and ``"lzf"`` are returned as strings,
+        optionally together with an HDF5 ``compression_opts`` value. Plugin-based
+        filters such as ``"lz4"`` and ``"zstd"`` are converted into the
+        corresponding filter objects provided by ``hdf5plugin``. In that case,
+        any user-provided ``compression_opts`` value is absorbed into the plugin
+        object and the returned HDF5 ``compression_opts`` is ``None``.
 
         Parameters
         ----------
@@ -104,18 +146,22 @@ class H5Writer:
             Compression algorithm identifier. Supported values are
 
             - ``None`` or ``"none"``: disable compression
-            - ``"lzf"``: built-in fast compression
             - ``"gzip"``: gzip/deflate compression
+            - ``"lzf"``: built-in fast compression
             - ``"lz4"``: LZ4 compression via ``hdf5plugin``
             - ``"zstd"``: Zstandard compression via ``hdf5plugin``
 
         Returns
         -------
-        str | object | None
-            Compression specification compatible with ``h5py.create_dataset``.
-            This is either a string (for built-in filters), an object returned
-            by ``hdf5plugin`` (for plugin filters), or ``None`` if compression
-            is disabled.
+        tuple[str | object | None, int | None]
+            Two-element tuple ``(compression, compression_opts)`` suitable for
+            passing to :meth:`h5py.File.create_dataset`.
+
+            - For no compression, returns ``(None, None)``.
+            - For built-in HDF5 filters, returns the filter name and optional
+              HDF5 ``compression_opts``.
+            - For plugin filters, returns the instantiated plugin object and
+              ``None``.
 
         Raises
         ------
@@ -123,25 +169,76 @@ class H5Writer:
             If the provided compression identifier is not supported.
         """
         if compression is None or compression == "none":
-            return None
+            return None, None
 
-        if compression in {"lzf", "gzip"}:
-            return compression
+        if compression == "gzip":
+            return "gzip", self.compression_opts
+
+        if compression == "lzf":
+            return "lzf", None
 
         if compression == "lz4":
-            return hdf5plugin.LZ4()
+            if self.compression_opts is None:
+                return hdf5plugin.LZ4(), None
+            return hdf5plugin.LZ4(clevel=self.compression_opts), None
 
         if compression == "zstd":
-            return hdf5plugin.Zstd()
+            if self.compression_opts is None:
+                return hdf5plugin.Zstd(), None
+            return hdf5plugin.Zstd(clevel=self.compression_opts), None
 
-        raise ValueError(
-            f"Unsupported compression '{compression}'. Supported: none, lzf, gzip, lz4, zstd."
-        )
+        raise ValueError(f"Unsupported compression: {compression}")
 
     @classmethod
     def from_file(
-        cls, source: Path, num_jets: int | None = 0, variables=None, copy_groups=True, **kwargs
+        cls,
+        source: Path | str,
+        num_jets: int | None = 0,
+        variables: dict[str, list[str] | None] | None = None,
+        copy_groups: bool = True,
+        **kwargs: Any,
     ) -> H5Writer:
+        """Construct a writer from the structure of an existing HDF5 file.
+
+        This class method inspects an input file and derives output dataset
+        dtypes, shapes, compression, and optionally metadata groups from it.
+        It can be used to create a writer that mirrors the input file layout,
+        optionally restricted to a subset of variables and/or a different number
+        of output jets.
+
+        Parameters
+        ----------
+        source : Path | str
+            Source HDF5 file from which to infer the output structure.
+        num_jets : int | None, optional
+            If non-zero, override the first dimension of all dataset shapes with
+            this value. If ``0``, keep the original dataset lengths. Default is
+            ``0``.
+        variables : dict[str, list[str] | None] | None, optional
+            Optional mapping from dataset name to a list of variables to keep.
+            If provided, output dtypes are reduced accordingly. Default is
+            ``None``.
+        copy_groups : bool, optional
+            If ``True``, copy non-dataset groups from the source file into the
+            created writer. Default is ``True``.
+        **kwargs : Any
+            Additional keyword arguments forwarded to the class constructor.
+            This can be used, for example, to override ``compression``,
+            ``compression_opts``, ``precision``, or ``full_precision_vars``.
+
+        Returns
+        -------
+        H5Writer
+            Writer initialized from the source file structure.
+
+        Raises
+        ------
+        TypeError
+            If an object in the source file is neither an HDF5 dataset nor group.
+        AssertionError
+            If the source file datasets do not all use the same compression and
+            no explicit ``compression`` override is provided.
+        """
         with h5py.File(source, "r") as f:
             dtypes = {}
             shapes = {}
@@ -161,20 +258,21 @@ class H5Writer:
                 compression.append(ds.compression)
 
             if variables:
-                new_dtye = {}
+                new_dtype = {}
                 new_shape = {}
                 for name, ds in f.items():
                     if name not in variables:
                         continue
-                    new_dtye[name] = ftag.hdf5.get_dtype(
+                    new_dtype[name] = ftag.hdf5.get_dtype(
                         ds,
                         variables=variables[name],
                         precision=kwargs.get("precision"),
                         full_precision_vars=kwargs.get("full_precision_vars"),
                     )
                     new_shape[name] = ds.shape
-                dtypes = new_dtye
+                dtypes = new_dtype
                 shapes = new_shape
+
             if num_jets != 0:
                 shapes = {name: (num_jets, *shape[1:]) for name, shape in shapes.items()}
 
@@ -182,51 +280,83 @@ class H5Writer:
             compression = compression[0]
             if "compression" not in kwargs:
                 kwargs["compression"] = compression
+
         return cls(dtypes=dtypes, shapes=shapes, groups=groups, **kwargs)
 
     def save_groups(self, groups: dict[str, dict]) -> None:
+        """Write extracted metadata groups into the output file.
+
+        Parameters
+        ----------
+        groups : dict[str, dict]
+            Mapping from group name to extracted group contents.
+        """
         for name, group_data in groups.items():
             if name not in self.file:
                 write_group_full(self.file.create_group(name), group_data)
 
     def create_ds(self, name: str, dtype: np.dtype) -> None:
+        """Create one output dataset.
+
+        Parameters
+        ----------
+        name : str
+            Dataset name.
+        dtype : np.dtype
+            Input dtype definition for the dataset.
+        """
         if name == self.jets_name and self.add_flavour_label and "flavour_label" not in dtype.names:
             dtype = np.dtype([*dtype.descr, ("flavour_label", "i4")])
 
         fp_vars = self.full_precision_vars or []
-        # If no precision is defined, or the field is in full_precision_vars, or its non-float,
-        # keep it at the original dtype
-        dtype = np.dtype([
-            (
-                field,
+        dtype = np.dtype(
+            [
                 (
-                    self.fp_dtype
-                    if (self.fp_dtype and field not in fp_vars and np.issubdtype(dt, np.floating))
-                    else dt
-                ),
-            )
-            for field, dt in dtype.descr
-        ])
+                    field,
+                    (
+                        self.fp_dtype
+                        if (
+                            self.fp_dtype
+                            and field not in fp_vars
+                            and np.issubdtype(dt, np.floating)
+                        )
+                        else dt
+                    ),
+                )
+                for field, dt in dtype.descr
+            ]
+        )
 
         shape = self.shapes[name]
         chunks = (100, *shape[1:]) if shape[1:] else None
+        kwargs = {
+            "dtype": dtype,
+            "compression": self.compression,
+            "chunks": chunks,
+        }
+        if self.compression_opts is not None:
+            kwargs["compression_opts"] = self.compression_opts
 
         if self.fixed_mode:
-            self.file.create_dataset(
-                name, dtype=dtype, shape=shape, compression=self.compression, chunks=chunks
-            )
+            self.file.create_dataset(name, shape=shape, **kwargs)
         else:
             maxshape = (None, *shape[1:])
             self.file.create_dataset(
                 name,
-                dtype=dtype,
                 shape=(0, *shape[1:]),
                 maxshape=maxshape,
-                compression=self.compression,
-                chunks=chunks,
+                **kwargs,
             )
 
     def close(self) -> None:
+        """Close the output file.
+
+        Raises
+        ------
+        ValueError
+            If the writer is closed before the expected number of jets has been
+            written in fixed-size mode.
+        """
         if self.fixed_mode:
             written = len(self.file[self.jets_name])
             if self.num_written != written:
@@ -237,15 +367,24 @@ class H5Writer:
         self.file.close()
 
     def get_attr(self, name, group=None):
+        """Return an attribute from the output file or one of its groups."""
         with h5py.File(self.dst) as f:
             obj = f[group] if group else f
             return obj.attrs[name]
 
     def add_attr(self, name, data, group=None) -> None:
+        """Add an attribute to the output file or one of its groups."""
         obj = self.file[group] if group else self.file
         obj.attrs.create(name, data)
 
     def copy_attrs(self, fname: Path) -> None:
+        """Copy file- and dataset-level attributes from another HDF5 file.
+
+        Parameters
+        ----------
+        fname : Path
+            Path to the source HDF5 file.
+        """
         with h5py.File(fname) as f:
             for name, value in f.attrs.items():
                 self.add_attr(name, value)
@@ -254,6 +393,18 @@ class H5Writer:
                     self.add_attr(attr_name, value, group=name)
 
     def write(self, data: dict[str, np.ndarray]) -> None:
+        """Write one batch of data to the output file.
+
+        Parameters
+        ----------
+        data : dict[str, np.ndarray]
+            Mapping from dataset name to batch array.
+
+        Raises
+        ------
+        ValueError
+            If writing this batch would exceed ``num_jets`` in fixed-size mode.
+        """
         batch_size = len(data[self.jets_name])
         idx = np.arange(batch_size)
         if self.shuffle:

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import h5py
+import hdf5plugin
 import numpy as np
 
 import ftag
@@ -26,8 +27,8 @@ class H5Writer:
         Name of the jets group. Default is "jets".
     add_flavour_label : bool, optional
         Whether to add a flavour label to the jets group. Default is False.
-    compression : str, optional
-        Compression algorithm to use. Default is "lzf".
+    compression : str | None, optional
+        Compression algorithm to use. Default is lz4.
     precision : str, optional
         Precision to use. Default is None.
     full_precision_vars : list[str] | None, optional
@@ -45,7 +46,7 @@ class H5Writer:
     shapes: dict[str, tuple[int, ...]]
     jets_name: str = "jets"
     add_flavour_label: bool = False
-    compression: str = "lzf"
+    compression: str | None = "lz4"
     precision: str = "full"
     full_precision_vars: list[str] | None = None
     shuffle: bool = True
@@ -75,6 +76,9 @@ class H5Writer:
         else:
             raise ValueError(f"Invalid precision: {self.precision}")
 
+        # Check compression
+        self.compression = self._resolve_compression(self.compression)
+
         self.dst = Path(self.dst)
         self.dst.parent.mkdir(parents=True, exist_ok=True)
         self.file = h5py.File(self.dst, "w")
@@ -84,6 +88,55 @@ class H5Writer:
             self.create_ds(name, dtype)
         if self.groups:
             self.save_groups(self.groups)
+
+    def _resolve_compression(self, compression: str | None) -> str | object | None:
+        """Resolve a user-facing compression string into an HDF5 compression spec.
+
+        This method converts a human-readable compression identifier into the
+        corresponding object or string expected by :func:`h5py.File.create_dataset`.
+        Built-in HDF5 filters (e.g. ``"gzip"``, ``"lzf"``) are returned unchanged,
+        while plugin-based filters (e.g. ``"lz4"``, ``"zstd"``) are converted into
+        the appropriate filter objects provided by ``hdf5plugin``.
+
+        Parameters
+        ----------
+        compression : str | None
+            Compression algorithm identifier. Supported values are
+
+            - ``None`` or ``"none"``: disable compression
+            - ``"lzf"``: built-in fast compression
+            - ``"gzip"``: gzip/deflate compression
+            - ``"lz4"``: LZ4 compression via ``hdf5plugin``
+            - ``"zstd"``: Zstandard compression via ``hdf5plugin``
+
+        Returns
+        -------
+        str | object | None
+            Compression specification compatible with ``h5py.create_dataset``.
+            This is either a string (for built-in filters), an object returned
+            by ``hdf5plugin`` (for plugin filters), or ``None`` if compression
+            is disabled.
+
+        Raises
+        ------
+        ValueError
+            If the provided compression identifier is not supported.
+        """
+        if compression is None or compression == "none":
+            return None
+
+        if compression in {"lzf", "gzip"}:
+            return compression
+
+        if compression == "lz4":
+            return hdf5plugin.LZ4()
+
+        if compression == "zstd":
+            return hdf5plugin.Zstd()
+
+        raise ValueError(
+            f"Unsupported compression '{compression}'. Supported: none, lzf, gzip, lz4, zstd."
+        )
 
     @classmethod
     def from_file(

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -65,7 +65,7 @@ class H5Writer:
         Expected total number of jets to write. If given, datasets are created
         in fixed-size mode. If ``None``, datasets are created in dynamic mode
         and resized during writing. Default is ``None``.
-    groups : dict[str, dict] | None, optional
+    groups : dict[str, h5py.Group] | None, optional
         Mapping of metadata group names to extracted group contents to be copied
         into the output file. Default is ``None``.
 
@@ -85,11 +85,11 @@ class H5Writer:
     add_flavour_label: bool = False
     compression: str | None = "lz4"
     compression_opts: int | None = None
-    precision: str = "full"
+    precision: str | None = "full"
     full_precision_vars: list[str] | None = None
     shuffle: bool = True
     num_jets: int | None = None
-    groups: dict[str, dict] | None = None
+    groups: dict[str, h5py.Group] | None = None
 
     def __post_init__(self) -> None:
         self.num_written = 0
@@ -114,7 +114,9 @@ class H5Writer:
         else:
             raise ValueError(f"Invalid precision: {self.precision}")
 
-        self.compression, self.compression_opts = self._resolve_compression(self.compression)
+        self.resolved_compression, self.resolved_compression_opts = self._resolve_compression(
+            self.compression
+        )
 
         self.dst = Path(self.dst)
         self.dst.parent.mkdir(parents=True, exist_ok=True)
@@ -169,25 +171,37 @@ class H5Writer:
             If the provided compression identifier is not supported.
         """
         if compression is None or compression == "none":
-            return None, None
+            used_compression = None
+            used_opts = None
 
-        if compression == "gzip":
-            return "gzip", self.compression_opts
+        elif compression == "gzip":
+            used_compression = "gzip"
+            used_opts = self.compression_opts
 
-        if compression == "lzf":
-            return "lzf", None
+        elif compression == "lzf":
+            used_compression = "lzf"
+            used_opts = None
 
-        if compression == "lz4":
+        elif compression == "lz4":
+            used_opts = None
             if self.compression_opts is None:
-                return hdf5plugin.LZ4(), None
-            return hdf5plugin.LZ4(clevel=self.compression_opts), None
+                used_compression = hdf5plugin.LZ4()
 
-        if compression == "zstd":
+            else:
+                used_compression = hdf5plugin.LZ4(clevel=self.compression_opts)
+
+        elif compression == "zstd":
+            used_opts = None
             if self.compression_opts is None:
-                return hdf5plugin.Zstd(), None
-            return hdf5plugin.Zstd(clevel=self.compression_opts), None
+                used_compression = hdf5plugin.Zstd()
 
-        raise ValueError(f"Unsupported compression: {compression}")
+            else:
+                used_compression = hdf5plugin.Zstd(clevel=self.compression_opts)
+
+        else:
+            raise ValueError(f"Unsupported compression: {compression}")
+
+        return used_compression, used_opts
 
     @classmethod
     def from_file(
@@ -235,9 +249,6 @@ class H5Writer:
         ------
         TypeError
             If an object in the source file is neither an HDF5 dataset nor group.
-        AssertionError
-            If the source file datasets do not all use the same compression and
-            no explicit ``compression`` override is provided.
         """
         with h5py.File(source, "r") as f:
             dtypes = {}
@@ -309,33 +320,27 @@ class H5Writer:
             dtype = np.dtype([*dtype.descr, ("flavour_label", "i4")])
 
         fp_vars = self.full_precision_vars or []
-        dtype = np.dtype(
-            [
+        dtype = np.dtype([
+            (
+                field,
                 (
-                    field,
-                    (
-                        self.fp_dtype
-                        if (
-                            self.fp_dtype
-                            and field not in fp_vars
-                            and np.issubdtype(dt, np.floating)
-                        )
-                        else dt
-                    ),
-                )
-                for field, dt in dtype.descr
-            ]
-        )
+                    self.fp_dtype
+                    if (self.fp_dtype and field not in fp_vars and np.issubdtype(dt, np.floating))
+                    else dt
+                ),
+            )
+            for field, dt in dtype.descr
+        ])
 
         shape = self.shapes[name]
         chunks = (100, *shape[1:]) if shape[1:] else None
         kwargs = {
             "dtype": dtype,
-            "compression": self.compression,
+            "compression": self.resolved_compression,
             "chunks": chunks,
         }
-        if self.compression_opts is not None:
-            kwargs["compression_opts"] = self.compression_opts
+        if self.resolved_compression_opts is not None:
+            kwargs["compression_opts"] = self.resolved_compression_opts
 
         if self.fixed_mode:
             self.file.create_dataset(name, shape=shape, **kwargs)
@@ -366,14 +371,40 @@ class H5Writer:
                 )
         self.file.close()
 
-    def get_attr(self, name, group=None):
-        """Return an attribute from the output file or one of its groups."""
+    def get_attr(self, name: str, group: str | None = None) -> Any:
+        """Return an attribute from the output file or one of its groups.
+
+        Parameters
+        ----------
+        name : str
+            Name of the attribute to retrieve.
+        group : str | None, optional
+            Name of the group from which the attribute should be read.
+            If ``None``, the attribute is read from the root of the HDF5 file.
+
+        Returns
+        -------
+        Any
+            Value of the requested attribute.
+        """
         with h5py.File(self.dst) as f:
             obj = f[group] if group else f
             return obj.attrs[name]
 
-    def add_attr(self, name, data, group=None) -> None:
-        """Add an attribute to the output file or one of its groups."""
+    def add_attr(self, name: str, data: Any, group: str | None = None) -> None:
+        """Add an attribute to the output file or one of its groups.
+
+        Parameters
+        ----------
+        name : str
+            Name of the attribute to create.
+        data : Any
+            Attribute value to store. The value must be compatible with
+            HDF5 attribute storage.
+        group : str | None, optional
+            Name of the group to which the attribute should be added.
+            If ``None``, the attribute is written to the root of the HDF5 file.
+        """
         obj = self.file[group] if group else self.file
         obj.attrs.create(name, data)
 
@@ -414,10 +445,12 @@ class H5Writer:
         low = self.num_written
         high = low + batch_size
 
-        if self.fixed_mode and high > self.num_jets:
-            raise ValueError(
-                f"Attempted to write more jets than expected: {high:,} > {self.num_jets:,}"
-            )
+        if self.fixed_mode:
+            assert self.num_jets is not None
+            if high > self.num_jets:
+                raise ValueError(
+                    f"Attempted to write more jets than expected: {high:,} > {self.num_jets:,}"
+                )
 
         for group in self.dtypes:
             ds = self.file[group]

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -327,9 +327,7 @@ def test_from_file_with_variable_subset(tmp_path):
     ("compression", "compression_opts"),
     [
         ("gzip", 1),
-        ("gzip", 4),
         ("gzip", 7),
-        ("gzip", 9),
     ],
 )
 def test_create_ds_with_gzip_compression_opts(

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -16,8 +16,6 @@ _PADDING_FIELD_RE = re.compile(r"^f\d+$")
 
 
 def _named_fields(dtype: np.dtype) -> tuple[str, ...]:
-    if dtype.names is None:
-        return ()
     return tuple(name for name in dtype.names if not _PADDING_FIELD_RE.fullmatch(name))
 
 

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import h5py
@@ -10,6 +11,30 @@ import pytest
 from ftag import get_mock_file
 from ftag.hdf5 import H5Writer
 from ftag.hdf5.h5utils import compare_groups
+
+_PADDING_FIELD_RE = re.compile(r"^f\d+$")
+
+
+def _named_fields(dtype: np.dtype) -> tuple[str, ...]:
+    if dtype.names is None:
+        return ()
+    return tuple(name for name in dtype.names if not _PADDING_FIELD_RE.fullmatch(name))
+
+
+def assert_structured_array_equal(actual: np.ndarray, expected: np.ndarray) -> None:
+    """Assert equality of two structured arrays field-by-field.
+
+    This comparison ignores anonymous padding fields such as ``f0``, ``f1``,
+    etc., which may be introduced by HDF5/h5py for compound dtypes.
+    """
+    assert actual.shape == expected.shape
+
+    actual_fields = _named_fields(actual.dtype)
+    expected_fields = _named_fields(expected.dtype)
+    assert actual_fields == expected_fields
+
+    for field in expected_fields:
+        assert np.array_equal(actual[field], expected[field]), f"Mismatch in field '{field}'"
 
 
 @pytest.fixture
@@ -33,11 +58,14 @@ def jet_dtype():
 
 def test_create_ds(tmp_path, jet_dtype):
     writer = H5Writer(
-        dst=Path(tmp_path) / "test.h5", dtypes={"jets": jet_dtype}, shapes={"jets": (100,)}
+        dst=Path(tmp_path) / "test.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
     )
 
     assert "jets" in writer.file
-    assert writer.file["jets"].dtype == jet_dtype
+    assert _named_fields(writer.file["jets"].dtype) == ("pt", "eta")
+    writer.close()
 
 
 def test_write(tmp_path, mock_data):
@@ -50,8 +78,10 @@ def test_write(tmp_path, mock_data):
 
     data = {"jets": mock_data[0]}
     writer.write(data)
+
     assert writer.num_written == len(data["jets"])
-    assert np.array_equal(writer.file["jets"][0 : writer.num_written], data["jets"])
+    assert_structured_array_equal(writer.file["jets"][0 : writer.num_written], data["jets"])
+    writer.close()
 
 
 def test_close(tmp_path, mock_data):
@@ -59,27 +89,31 @@ def test_close(tmp_path, mock_data):
         dst=Path(tmp_path) / "test.h5",
         dtypes={"jets": np.dtype([("pt", "f4"), ("eta", "f4")])},
         shapes={"jets": (100,)},
+        num_jets=100,
+        shuffle=False,
     )
 
     data = {"jets": mock_data[0]}
     writer.write(data)
     writer.close()
 
-    with pytest.raises(KeyError):
-        writer.file["jets"].resize(writer.num_written)
+    assert not writer.file.id.valid
 
 
 def test_add_attr(tmp_path, jet_dtype):
     writer = H5Writer(
-        dst=Path(tmp_path) / "test.h5", dtypes={"jets": jet_dtype}, shapes={"jets": (100,)}
+        dst=Path(tmp_path) / "test.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
     )
 
     writer.add_attr("test_attr", "test_value")
     assert "test_attr" in writer.file.attrs
     assert writer.get_attr("test_attr") == "test_value"
+    writer.close()
 
 
-def test_post_init(tmp_path, jet_dtype):
+def test_post_init_fixed_mode(tmp_path, jet_dtype):
     writer = H5Writer(
         dst=Path(tmp_path) / "test.h5",
         dtypes={"jets": jet_dtype},
@@ -88,8 +122,22 @@ def test_post_init(tmp_path, jet_dtype):
     )
 
     assert writer.num_jets == 100
+    assert writer.fixed_mode is True
     assert writer.dst == Path(tmp_path) / "test.h5"
     assert writer.rng is not None
+
+
+def test_post_init_dynamic_mode(tmp_path, jet_dtype):
+    writer = H5Writer(
+        dst=Path(tmp_path) / "test_dynamic.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        num_jets=None,
+    )
+
+    assert writer.num_jets is None
+    assert writer.fixed_mode is False
+    writer.close()
 
 
 def test_invalid_write(tmp_path, jet_dtype):
@@ -101,7 +149,7 @@ def test_invalid_write(tmp_path, jet_dtype):
     )
 
     data = {"jets": np.zeros(110, dtype=writer.dtypes["jets"])}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Attempted to write more jets than expected"):
         writer.write(data)
 
 
@@ -115,10 +163,12 @@ def test_from_file(tmp_path, mock_data_path):
     writer = H5Writer.from_file(source=mock_data_path, dst=dst_path, shuffle=False)
 
     writer.write({"jets": jets, "tracks": tracks})
-    with h5py.File(dst_path) as f:
-        assert np.array_equal(f["jets"][:], jets)
-        assert np.array_equal(f["tracks"][:], tracks)
-        compare_groups(f["cutBookkeeper"], cutbookkeeper, path="cutBookkeeper")
+    writer.close()
+
+    with h5py.File(dst_path) as f_out:
+        assert_structured_array_equal(f_out["jets"][:], jets)
+        assert_structured_array_equal(f_out["tracks"][:], tracks)
+        compare_groups(f_out["cutBookkeeper"], cutbookkeeper, path="cutBookkeeper")
 
 
 def test_from_file_no_groups(tmp_path, mock_data_path):
@@ -126,12 +176,18 @@ def test_from_file_no_groups(tmp_path, mock_data_path):
     f = get_mock_file()[1]
     jets = f["jets"][:]
     tracks = f["tracks"][:]
+
     writer = H5Writer.from_file(
-        source=mock_data_path, dst=dst_path, copy_groups=False, shuffle=False
+        source=mock_data_path,
+        dst=dst_path,
+        copy_groups=False,
+        shuffle=False,
     )
     writer.write({"jets": jets, "tracks": tracks})
-    with h5py.File(dst_path) as f:
-        assert "cutBookkeeper" not in f
+    writer.close()
+
+    with h5py.File(dst_path) as f_out:
+        assert "cutBookkeeper" not in f_out
 
 
 def test_half_full_precision(tmp_path, mock_data_path):
@@ -148,20 +204,23 @@ def test_half_full_precision(tmp_path, mock_data_path):
     )
 
     writer.write(f_old)
-    with h5py.File(dst_path) as f:
+    writer.close()
+
+    with h5py.File(dst_path) as f_new:
         for key in ["jets", "tracks"]:
-            for v in f[key].dtype.names:
-                dt = np.dtype(f_old[key].dtype[v])
-                dt_writer = np.dtype(f[key].dtype[v])
-                if not np.issubdtype(dt, np.floating):
+            for v in _named_fields(f_new[key].dtype):
+                dt_old = np.dtype(f_old[key].dtype[v])
+                dt_new = np.dtype(f_new[key].dtype[v])
+
+                if not np.issubdtype(dt_old, np.floating):
                     continue
 
                 if v in full_precision_vars:
-                    assert dt == np.float32
-                    assert dt_writer == np.float32
+                    assert dt_old == np.float32
+                    assert dt_new == np.float32
                 else:
-                    assert dt == np.float32
-                    assert dt_writer == np.float16
+                    assert dt_old == np.float32
+                    assert dt_new == np.float16
 
 
 def test_dynamic_mode_write(tmp_path, mock_data):
@@ -174,20 +233,21 @@ def test_dynamic_mode_write(tmp_path, mock_data):
         dst=Path(tmp_path) / "test_dynamic.h5",
         dtypes=dtypes,
         shapes=shapes,
-        num_jets=None,  # Allow dynamic sizing
+        num_jets=None,
         shuffle=False,
     )
 
     writer.write(data)
     assert writer.num_written == len(data["jets"])
 
-    # Should allow further writes without reshaping issues
     writer.write(data)
     assert writer.num_written == 2 * len(data["jets"])
 
     writer.close()
+
     with h5py.File(writer.dst) as f:
         assert f["jets"].shape[0] == 2 * len(data["jets"])
+        assert f["tracks"].shape[0] == 2 * len(data["tracks"])
 
 
 def test_precision_none_preserves_dtypes(tmp_path, mock_data):
@@ -208,7 +268,7 @@ def test_precision_none_preserves_dtypes(tmp_path, mock_data):
 
     with h5py.File(writer.dst) as f:
         for name in ["jets", "tracks"]:
-            for field in dtypes[name].names:
+            for field in _named_fields(dtypes[name]):
                 expected_dtype = dtypes[name][field]
                 actual_dtype = f[name].dtype[field]
                 assert actual_dtype == expected_dtype, (
@@ -217,7 +277,6 @@ def test_precision_none_preserves_dtypes(tmp_path, mock_data):
 
 
 def test_close_raises_on_incomplete_write(tmp_path, jet_dtype):
-    # Set up writer with fixed mode (num_jets set)
     writer = H5Writer(
         dst=Path(tmp_path) / "test_close_incomplete.h5",
         dtypes={"jets": jet_dtype},
@@ -226,17 +285,14 @@ def test_close_raises_on_incomplete_write(tmp_path, jet_dtype):
         shuffle=False,
     )
 
-    # Only write part of the data (e.g., 60 jets instead of 100)
     partial_data = {"jets": np.zeros(60, dtype=writer.dtypes["jets"])}
     writer.write(partial_data)
 
-    # Closing should now raise ValueError
     with pytest.raises(ValueError, match="only 60 out of 100 jets have been written"):
         writer.close()
 
 
 def test_from_file_with_variable_subset(tmp_path):
-    # Create an HDF5 file with known structure
     path = tmp_path / "test_subset.h5"
     with h5py.File(path, "w") as f:
         jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4"), ("phi", "f4")])
@@ -246,10 +302,9 @@ def test_from_file_with_variable_subset(tmp_path):
         f.create_dataset("tracks", data=tracks, compression="lzf")
         f.create_dataset("flows", data=flows, compression="lzf")
 
-    # Only want a subset of variables
     variables = {
-        "jets": ["pt", "eta"],  # exclude "phi"
-        "tracks": ["d0"],  # exclude "z0"
+        "jets": ["pt", "eta"],
+        "tracks": ["d0"],
     }
 
     writer = H5Writer.from_file(
@@ -260,15 +315,14 @@ def test_from_file_with_variable_subset(tmp_path):
         precision=None,
     )
 
-    # Check only the requested variables are present in the dtypes
     assert "jets" in writer.dtypes
     assert "tracks" in writer.dtypes
-    assert writer.dtypes["jets"].names == ("pt", "eta")
-    assert writer.dtypes["tracks"].names == ("d0",)
-
-    # Check shapes respect the updated num_jets
+    assert _named_fields(writer.dtypes["jets"]) == ("pt", "eta")
+    assert _named_fields(writer.dtypes["tracks"]) == ("d0",)
     assert writer.shapes["jets"][0] == 10
     assert writer.shapes["tracks"][0] == 10
+
+    writer.close()
 
 
 @pytest.mark.parametrize(
@@ -278,11 +332,14 @@ def test_from_file_with_variable_subset(tmp_path):
         ("none", None),
         ("lzf", "lzf"),
         ("gzip", "gzip"),
-        ("lz4", hdf5plugin.LZ4.filter_id),
-        ("zstd", hdf5plugin.Zstd.filter_id),
     ],
 )
-def test_create_ds_with_compression(tmp_path, jet_dtype, compression, expected_compression):
+def test_create_ds_with_builtin_or_none_compression(
+    tmp_path,
+    jet_dtype,
+    compression,
+    expected_compression,
+):
     writer = H5Writer(
         dst=Path(tmp_path) / f"test_{compression}.h5",
         dtypes={"jets": jet_dtype},
@@ -291,18 +348,98 @@ def test_create_ds_with_compression(tmp_path, jet_dtype, compression, expected_c
     )
 
     ds = writer.file["jets"]
-    assert "jets" in writer.file
-
-    if compression in {None, "none", "lzf", "gzip"}:
-        assert ds.compression == expected_compression
-    else:
-        assert ds.compression is None
-        assert ds.compression_opts is not None
-
+    assert ds.compression == expected_compression
     writer.close()
 
 
-@pytest.mark.parametrize("compression", [None, "none", "lzf", "gzip", "lz4", "zstd"])
+@pytest.mark.parametrize(
+    ("compression", "filter_id"),
+    [
+        ("lz4", hdf5plugin.LZ4.filter_id),
+        ("zstd", hdf5plugin.Zstd.filter_id),
+    ],
+)
+def test_create_ds_with_plugin_compression(tmp_path, jet_dtype, compression, filter_id):
+    writer = H5Writer(
+        dst=Path(tmp_path) / f"test_{compression}.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        compression=compression,
+    )
+
+    ds = writer.file["jets"]
+    plist = ds.id.get_create_plist()
+    filters = [plist.get_filter(i)[0] for i in range(plist.get_nfilters())]
+
+    assert filter_id in filters
+    writer.close()
+
+
+@pytest.mark.parametrize(
+    ("compression", "compression_opts"),
+    [
+        ("gzip", 1),
+        ("gzip", 4),
+        ("gzip", 7),
+        ("gzip", 9),
+    ],
+)
+def test_create_ds_with_gzip_compression_opts(
+    tmp_path,
+    jet_dtype,
+    compression,
+    compression_opts,
+):
+    writer = H5Writer(
+        dst=Path(tmp_path) / f"test_{compression}_{compression_opts}.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        compression=compression,
+        compression_opts=compression_opts,
+    )
+
+    ds = writer.file["jets"]
+    assert ds.compression == "gzip"
+    assert ds.compression_opts == compression_opts
+    writer.close()
+
+
+@pytest.mark.parametrize(
+    ("compression", "compression_opts", "filter_id"),
+    [
+        ("lz4", None, hdf5plugin.LZ4.filter_id),
+        ("zstd", None, hdf5plugin.Zstd.filter_id),
+        ("zstd", 3, hdf5plugin.Zstd.filter_id),
+        ("zstd", 9, hdf5plugin.Zstd.filter_id),
+    ],
+)
+def test_create_ds_with_plugin_compression_opts(
+    tmp_path,
+    jet_dtype,
+    compression,
+    compression_opts,
+    filter_id,
+):
+    writer = H5Writer(
+        dst=Path(tmp_path) / f"test_{compression}_{compression_opts}.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        compression=compression,
+        compression_opts=compression_opts,
+    )
+
+    ds = writer.file["jets"]
+    plist = ds.id.get_create_plist()
+    filters = [plist.get_filter(i)[0] for i in range(plist.get_nfilters())]
+
+    assert filter_id in filters
+    writer.close()
+
+
+@pytest.mark.parametrize(
+    "compression",
+    [None, "none", "lzf", "gzip", "lz4", "zstd"],
+)
 def test_write_with_compression(tmp_path, mock_data, compression):
     jets, tracks = mock_data
     dtypes = {"jets": jets.dtype, "tracks": tracks.dtype}
@@ -313,6 +450,7 @@ def test_write_with_compression(tmp_path, mock_data, compression):
         dtypes=dtypes,
         shapes=shapes,
         compression=compression,
+        precision=None,
         shuffle=False,
     )
 
@@ -320,8 +458,40 @@ def test_write_with_compression(tmp_path, mock_data, compression):
     writer.close()
 
     with h5py.File(writer.dst) as f:
-        assert np.array_equal(f["jets"][:], jets)
-        assert np.array_equal(f["tracks"][:], tracks)
+        assert_structured_array_equal(f["jets"][:], jets)
+        assert_structured_array_equal(f["tracks"][:], tracks)
+
+
+@pytest.mark.parametrize(
+    ("compression", "compression_opts"),
+    [
+        ("gzip", 4),
+        ("gzip", 7),
+        ("zstd", 3),
+        ("zstd", 9),
+    ],
+)
+def test_write_with_compression_opts(tmp_path, mock_data, compression, compression_opts):
+    jets, tracks = mock_data
+    dtypes = {"jets": jets.dtype, "tracks": tracks.dtype}
+    shapes = {"jets": jets.shape, "tracks": tracks.shape}
+
+    writer = H5Writer(
+        dst=Path(tmp_path) / f"test_write_{compression}_{compression_opts}.h5",
+        dtypes=dtypes,
+        shapes=shapes,
+        compression=compression,
+        compression_opts=compression_opts,
+        precision=None,
+        shuffle=False,
+    )
+
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(writer.dst) as f:
+        assert_structured_array_equal(f["jets"][:], jets)
+        assert_structured_array_equal(f["tracks"][:], tracks)
 
 
 @pytest.mark.parametrize("compression", ["invalid", "foo", "lz5"])
@@ -336,7 +506,7 @@ def test_invalid_compression_raises(tmp_path, jet_dtype, compression):
 
 
 @pytest.mark.parametrize("compression", ["lzf", "gzip"])
-def test_from_file_preserves_compression(tmp_path, compression):
+def test_from_file_preserves_builtin_compression(tmp_path, compression):
     src_path = tmp_path / f"source_{compression}.h5"
     dst_path = tmp_path / f"dest_{compression}.h5"
 
@@ -347,15 +517,74 @@ def test_from_file_preserves_compression(tmp_path, compression):
         f.create_dataset("jets", data=jets, compression=compression)
         f.create_dataset("tracks", data=tracks, compression=compression)
 
-    writer = H5Writer.from_file(source=src_path, dst=dst_path, shuffle=False)
+    writer = H5Writer.from_file(source=src_path, dst=dst_path, shuffle=False, precision=None)
     writer.write({"jets": jets, "tracks": tracks})
     writer.close()
 
     with h5py.File(dst_path) as f:
         assert f["jets"].compression == compression
         assert f["tracks"].compression == compression
-        assert np.array_equal(f["jets"][:], jets)
-        assert np.array_equal(f["tracks"][:], tracks)
+        assert_structured_array_equal(f["jets"][:], jets)
+        assert_structured_array_equal(f["tracks"][:], tracks)
+
+
+def test_from_file_preserves_gzip_compression_opts(tmp_path):
+    src_path = tmp_path / "source_gzip4.h5"
+    dst_path = tmp_path / "dest_gzip4.h5"
+
+    jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4")])
+    tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
+
+    with h5py.File(src_path, "w") as f:
+        f.create_dataset("jets", data=jets, compression="gzip", compression_opts=4)
+        f.create_dataset("tracks", data=tracks, compression="gzip", compression_opts=4)
+
+    writer = H5Writer.from_file(source=src_path, dst=dst_path, shuffle=False, precision=None)
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(dst_path) as f:
+        assert f["jets"].compression == "gzip"
+        assert f["tracks"].compression == "gzip"
+        assert f["jets"].compression_opts == 4
+        assert f["tracks"].compression_opts == 4
+
+
+@pytest.mark.parametrize(
+    ("compression", "filter_id"),
+    [
+        ("lz4", hdf5plugin.LZ4.filter_id),
+        ("zstd", hdf5plugin.Zstd.filter_id),
+    ],
+)
+def test_from_file_preserves_plugin_compression(tmp_path, compression, filter_id):
+    src_path = tmp_path / f"source_{compression}.h5"
+    dst_path = tmp_path / f"dest_{compression}.h5"
+
+    jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4")])
+    tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
+
+    plugin = hdf5plugin.LZ4() if compression == "lz4" else hdf5plugin.Zstd()
+
+    with h5py.File(src_path, "w") as f:
+        f.create_dataset("jets", data=jets, compression=plugin)
+        f.create_dataset("tracks", data=tracks, compression=plugin)
+
+    writer = H5Writer.from_file(
+        source=src_path,
+        dst=dst_path,
+        shuffle=False,
+        compression=compression,
+        precision=None,
+    )
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(dst_path) as f:
+        for name in ["jets", "tracks"]:
+            plist = f[name].id.get_create_plist()
+            filters = [plist.get_filter(i)[0] for i in range(plist.get_nfilters())]
+            assert filter_id in filters
 
 
 def test_from_file_override_compression(tmp_path):
@@ -374,6 +603,7 @@ def test_from_file_override_compression(tmp_path):
         dst=dst_path,
         shuffle=False,
         compression="gzip",
+        precision=None,
     )
     writer.write({"jets": jets, "tracks": tracks})
     writer.close()
@@ -381,3 +611,69 @@ def test_from_file_override_compression(tmp_path):
     with h5py.File(dst_path) as f:
         assert f["jets"].compression == "gzip"
         assert f["tracks"].compression == "gzip"
+
+
+def test_from_file_override_compression_and_opts(tmp_path):
+    src_path = tmp_path / "source_lzf.h5"
+    dst_path = tmp_path / "dest_gzip7.h5"
+
+    jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4")])
+    tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
+
+    with h5py.File(src_path, "w") as f:
+        f.create_dataset("jets", data=jets, compression="lzf")
+        f.create_dataset("tracks", data=tracks, compression="lzf")
+
+    writer = H5Writer.from_file(
+        source=src_path,
+        dst=dst_path,
+        shuffle=False,
+        compression="gzip",
+        compression_opts=7,
+        precision=None,
+    )
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(dst_path) as f:
+        assert f["jets"].compression == "gzip"
+        assert f["tracks"].compression == "gzip"
+        assert f["jets"].compression_opts == 7
+        assert f["tracks"].compression_opts == 7
+
+
+def test_add_flavour_label(tmp_path, jet_dtype):
+    writer = H5Writer(
+        dst=Path(tmp_path) / "test_flavour_label.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (10,)},
+        add_flavour_label=True,
+    )
+
+    assert "flavour_label" in _named_fields(writer.file["jets"].dtype)
+    writer.close()
+
+
+def test_add_flavour_label_does_not_duplicate(tmp_path):
+    jet_dtype_with_label = np.dtype([("pt", "f4"), ("eta", "f4"), ("flavour_label", "i4")])
+
+    writer = H5Writer(
+        dst=Path(tmp_path) / "test_flavour_label_existing.h5",
+        dtypes={"jets": jet_dtype_with_label},
+        shapes={"jets": (10,)},
+        add_flavour_label=True,
+    )
+
+    assert _named_fields(writer.file["jets"].dtype).count("flavour_label") == 1
+    writer.close()
+
+
+@pytest.mark.parametrize("precision", ["bad", "float32", "quarter"])
+def test_invalid_precision_raises(tmp_path, jet_dtype, precision):
+    with pytest.raises(ValueError, match="Invalid precision"):
+        H5Writer(
+            dst=Path(tmp_path) / "test_invalid_precision.h5",
+            dtypes={"jets": jet_dtype},
+            shapes={"jets": (10,)},
+            precision=precision,
+        )

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import h5py
+import hdf5plugin
 import numpy as np
 import pytest
 
@@ -268,3 +269,115 @@ def test_from_file_with_variable_subset(tmp_path):
     # Check shapes respect the updated num_jets
     assert writer.shapes["jets"][0] == 10
     assert writer.shapes["tracks"][0] == 10
+
+
+@pytest.mark.parametrize(
+    ("compression", "expected_compression"),
+    [
+        (None, None),
+        ("none", None),
+        ("lzf", "lzf"),
+        ("gzip", "gzip"),
+        ("lz4", hdf5plugin.LZ4.filter_id),
+        ("zstd", hdf5plugin.Zstd.filter_id),
+    ],
+)
+def test_create_ds_with_compression(tmp_path, jet_dtype, compression, expected_compression):
+    writer = H5Writer(
+        dst=Path(tmp_path) / f"test_{compression}.h5",
+        dtypes={"jets": jet_dtype},
+        shapes={"jets": (100,)},
+        compression=compression,
+    )
+
+    ds = writer.file["jets"]
+    assert "jets" in writer.file
+
+    if compression in {None, "none", "lzf", "gzip"}:
+        assert ds.compression == expected_compression
+    else:
+        assert ds.compression is None
+        assert ds.compression_opts is not None
+
+    writer.close()
+
+
+@pytest.mark.parametrize("compression", [None, "none", "lzf", "gzip", "lz4", "zstd"])
+def test_write_with_compression(tmp_path, mock_data, compression):
+    jets, tracks = mock_data
+    dtypes = {"jets": jets.dtype, "tracks": tracks.dtype}
+    shapes = {"jets": jets.shape, "tracks": tracks.shape}
+
+    writer = H5Writer(
+        dst=Path(tmp_path) / f"test_write_{compression}.h5",
+        dtypes=dtypes,
+        shapes=shapes,
+        compression=compression,
+        shuffle=False,
+    )
+
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(writer.dst) as f:
+        assert np.array_equal(f["jets"][:], jets)
+        assert np.array_equal(f["tracks"][:], tracks)
+
+
+@pytest.mark.parametrize("compression", ["invalid", "foo", "lz5"])
+def test_invalid_compression_raises(tmp_path, jet_dtype, compression):
+    with pytest.raises(ValueError, match="Unsupported compression"):
+        H5Writer(
+            dst=Path(tmp_path) / "test_invalid_compression.h5",
+            dtypes={"jets": jet_dtype},
+            shapes={"jets": (100,)},
+            compression=compression,
+        )
+
+
+@pytest.mark.parametrize("compression", ["lzf", "gzip"])
+def test_from_file_preserves_compression(tmp_path, compression):
+    src_path = tmp_path / f"source_{compression}.h5"
+    dst_path = tmp_path / f"dest_{compression}.h5"
+
+    jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4")])
+    tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
+
+    with h5py.File(src_path, "w") as f:
+        f.create_dataset("jets", data=jets, compression=compression)
+        f.create_dataset("tracks", data=tracks, compression=compression)
+
+    writer = H5Writer.from_file(source=src_path, dst=dst_path, shuffle=False)
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(dst_path) as f:
+        assert f["jets"].compression == compression
+        assert f["tracks"].compression == compression
+        assert np.array_equal(f["jets"][:], jets)
+        assert np.array_equal(f["tracks"][:], tracks)
+
+
+def test_from_file_override_compression(tmp_path):
+    src_path = tmp_path / "source_lzf.h5"
+    dst_path = tmp_path / "dest_gzip.h5"
+
+    jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4")])
+    tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
+
+    with h5py.File(src_path, "w") as f:
+        f.create_dataset("jets", data=jets, compression="lzf")
+        f.create_dataset("tracks", data=tracks, compression="lzf")
+
+    writer = H5Writer.from_file(
+        source=src_path,
+        dst=dst_path,
+        shuffle=False,
+        compression="gzip",
+    )
+    writer.write({"jets": jets, "tracks": tracks})
+    writer.close()
+
+    with h5py.File(dst_path) as f:
+        assert f["jets"].compression == "gzip"
+        assert f["tracks"].compression == "gzip"

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -324,56 +324,6 @@ def test_from_file_with_variable_subset(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("compression", "expected_compression"),
-    [
-        (None, None),
-        ("none", None),
-        ("lzf", "lzf"),
-        ("gzip", "gzip"),
-    ],
-)
-def test_create_ds_with_builtin_or_none_compression(
-    tmp_path,
-    jet_dtype,
-    compression,
-    expected_compression,
-):
-    writer = H5Writer(
-        dst=Path(tmp_path) / f"test_{compression}.h5",
-        dtypes={"jets": jet_dtype},
-        shapes={"jets": (100,)},
-        compression=compression,
-    )
-
-    ds = writer.file["jets"]
-    assert ds.compression == expected_compression
-    writer.close()
-
-
-@pytest.mark.parametrize(
-    ("compression", "filter_id"),
-    [
-        ("lz4", hdf5plugin.LZ4.filter_id),
-        ("zstd", hdf5plugin.Zstd.filter_id),
-    ],
-)
-def test_create_ds_with_plugin_compression(tmp_path, jet_dtype, compression, filter_id):
-    writer = H5Writer(
-        dst=Path(tmp_path) / f"test_{compression}.h5",
-        dtypes={"jets": jet_dtype},
-        shapes={"jets": (100,)},
-        compression=compression,
-    )
-
-    ds = writer.file["jets"]
-    plist = ds.id.get_create_plist()
-    filters = [plist.get_filter(i)[0] for i in range(plist.get_nfilters())]
-
-    assert filter_id in filters
-    writer.close()
-
-
-@pytest.mark.parametrize(
     ("compression", "compression_opts"),
     [
         ("gzip", 1),
@@ -453,38 +403,7 @@ def test_write_with_compression(tmp_path, mock_data, compression):
     )
 
     writer.write({"jets": jets, "tracks": tracks})
-    writer.close()
-
-    with h5py.File(writer.dst) as f:
-        assert_structured_array_equal(f["jets"][:], jets)
-        assert_structured_array_equal(f["tracks"][:], tracks)
-
-
-@pytest.mark.parametrize(
-    ("compression", "compression_opts"),
-    [
-        ("gzip", 4),
-        ("gzip", 7),
-        ("zstd", 3),
-        ("zstd", 9),
-    ],
-)
-def test_write_with_compression_opts(tmp_path, mock_data, compression, compression_opts):
-    jets, tracks = mock_data
-    dtypes = {"jets": jets.dtype, "tracks": tracks.dtype}
-    shapes = {"jets": jets.shape, "tracks": tracks.shape}
-
-    writer = H5Writer(
-        dst=Path(tmp_path) / f"test_write_{compression}_{compression_opts}.h5",
-        dtypes=dtypes,
-        shapes=shapes,
-        compression=compression,
-        compression_opts=compression_opts,
-        precision=None,
-        shuffle=False,
-    )
-
-    writer.write({"jets": jets, "tracks": tracks})
+    assert writer.file["jets"].compression == compression
     writer.close()
 
     with h5py.File(writer.dst) as f:
@@ -586,32 +505,6 @@ def test_from_file_preserves_plugin_compression(tmp_path, compression, filter_id
 
 
 def test_from_file_override_compression(tmp_path):
-    src_path = tmp_path / "source_lzf.h5"
-    dst_path = tmp_path / "dest_gzip.h5"
-
-    jets = np.zeros(10, dtype=[("pt", "f4"), ("eta", "f4")])
-    tracks = np.zeros((10, 5), dtype=[("d0", "f4"), ("z0", "f4")])
-
-    with h5py.File(src_path, "w") as f:
-        f.create_dataset("jets", data=jets, compression="lzf")
-        f.create_dataset("tracks", data=tracks, compression="lzf")
-
-    writer = H5Writer.from_file(
-        source=src_path,
-        dst=dst_path,
-        shuffle=False,
-        compression="gzip",
-        precision=None,
-    )
-    writer.write({"jets": jets, "tracks": tracks})
-    writer.close()
-
-    with h5py.File(dst_path) as f:
-        assert f["jets"].compression == "gzip"
-        assert f["tracks"].compression == "gzip"
-
-
-def test_from_file_override_compression_and_opts(tmp_path):
     src_path = tmp_path / "source_lzf.h5"
     dst_path = tmp_path / "dest_gzip7.h5"
 

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -401,7 +401,6 @@ def test_write_with_compression(tmp_path, mock_data, compression):
     )
 
     writer.write({"jets": jets, "tracks": tracks})
-    assert writer.file["jets"].compression == compression
     writer.close()
 
     with h5py.File(writer.dst) as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10,<3.12"
 
 dependencies = [
   "h5py>=3.14.0",
+  "hdf5plugin>=6.0.0",
   "numpy>=2.2.6",
   "PyYAML>=6.0.2",
   "scipy>=1.15.3"


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Adding support for `LZ4` and `Zstd` compression (much faster than `LZF` and `GZIP`)
* Change default compression to `LZ4` for the `H5Writer`
* Adding unit tests for the new compression features
* Updated the docstrings a bit using my favourite LLM

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
