### PR TITLE
Metadata finder upgrade

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### [Latest]
 
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
+- Refactored `find_metadata.py` into a formal `MetadataFinder` class to improve modularity and facilitate integration with the ftag library for UPP. [#153](https://github.com/umami-hep/atlas-ftag-tools/pull/153)
 
 ### [v0.3.2](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.2) (25.02.2026)
 

--- a/ftag/find_metadata.py
+++ b/ftag/find_metadata.py
@@ -1,423 +1,191 @@
 from __future__ import annotations
 
-import argparse
 import json
 import re
 from pathlib import Path
-from typing import Any
-from urllib.parse import ParseResult, urlparse
 
 import h5py
 import requests
-import yaml
 
-"""
-find_metadata.py
-
-Injects metadata (cross_section_pb, genFiltEff, kfactor) into .h5 files produced by TDD.
-
-Usage:
-    python find_metadata.py <h5_file1> [<h5_file2> ...] [-m fallback.yaml]
-"""
-
-XSECDB_MAP: dict[str, str] = {
+# Mapping of campaign names to their respective PMG database files
+XSECDB_MAP = {
     "mc15": "PMGxsecDB_mc15.txt",
     "mc16": "PMGxsecDB_mc16.txt",
     "mc21": "PMGxsecDB_mc21.txt",
     "mc23": "PMGxsecDB_mc23.txt",
 }
-
-XSECDB_URL_BASE: str = "https://atlas-groupdata.web.cern.ch/atlas-groupdata/dev/PMGTools/"
-
-
-def validate_url_scheme(url: str) -> ParseResult:
-    """
-    Validate the scheme of a given URL, ensuring it is http or https.
-
-    Parameters
-    ----------
-    url : str
-        URL string to validate.
-
-    Returns
-    -------
-    ParseResult
-        Parsed URL object.
-
-    Raises
-    ------
-    ValueError
-        If the URL scheme is not supported.
-    """
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
-        raise ValueError(f"Unsupported URL scheme: {parsed.scheme}")
-    return parsed
+# Base URL for the PMG Tools group data at CERN
+XSECDB_URL_BASE = "https://atlas-groupdata.web.cern.ch/atlas-groupdata/dev/PMGTools/"
 
 
-def download_xsecdb_files() -> None:
-    """Download the PMG xsecDB files from CERN if they are not present locally."""
-    for filename in XSECDB_MAP.values():
-        if not Path(filename).exists():
-            url = XSECDB_URL_BASE + filename
-            try:
-                validate_url_scheme(url)
-                print(f"Downloading {filename} from {url}")
-                response = requests.get(url, timeout=10)
-                response.raise_for_status()
-                Path(filename).write_bytes(response.content)
-                print(f"Downloaded: {filename}")
-            except (requests.RequestException, ValueError) as e:
-                print(f"ERROR: Failed to download {filename} - {e}")
-
-
-def extract_taskid_from_filename(h5_path: Path) -> str | None:
-    """Extract the BigPanDA Task ID (8-digit) from an HDF5 filename.
+class MetadataFinder:
+    """Fetch and inject metadata into .h5 files.
 
     Parameters
     ----------
-    h5_path : Path
-        Path object pointing to the .h5 file.
-
-    Returns
-    -------
-    str | None
-        The Task ID as a string if found, otherwise None.
+    h5_path : str
+        Path to the HDF5 file where metadata should be injected.
     """
-    m = re.search(r"\.(\d{8})\.", h5_path.name)
-    return m.group(1) if m else None
 
+    def __init__(self, h5_path: str):
+        self.h5_path = Path(h5_path)
 
-def fetch_taskinfo_from_bigpanda(taskid: str) -> dict[str, Any] | None:
-    """Fetch task information from BigPanDA for a given Task ID.
+    def _extract_taskid(self) -> str | None:
+        """Extract the 8-digit BigPanDA Task ID from the filename.
 
-    Parameters
-    ----------
-    taskid : str
-        BigPanDA task ID.
+        Returns
+        -------
+        str | None
+            The extracted Task ID, or ``None`` if no match is found.
+        """
+        m = re.search(r"\.(\d{8})\.", self.h5_path.name)
+        return m.group(1) if m else None
 
-    Returns
-    -------
-    dict[str, Any] | None
-        Task info as a dictionary if found, otherwise None.
-    """
-    url = f"https://bigpanda.cern.ch/tasks/?jeditaskid={taskid}&json"
-    print(f"Fetching task info from: {url}")
-    try:
-        validate_url_scheme(url)
-        response = requests.get(url, timeout=10)
-        response.raise_for_status()
-        data = response.json()
-        if isinstance(data, list) and data:
-            return data[0]
-        print("No task info found.")
-    except (requests.RequestException, ValueError, json.JSONDecodeError) as e:
-        print(f"ERROR: Failed to fetch task info for {taskid} - {e}")
-    return None
+    def _fetch_taskinfo(self, taskid: str) -> dict | None:
+        """Fetch task details from the BigPanDA JSON API.
 
+        Parameters
+        ----------
+        taskid : str
+            The BigPanDA Task ID.
 
-def extract_mc_container_from_json(data: dict[str, Any]) -> str | None:
-    """Extract the MC container name (e.g., mc16_13TeV.<something>) from a task JSON.
+        Returns
+        -------
+        dict | None
+            The first task record from the API response, or ``None`` if unavailable.
+        """
+        url = f"https://bigpanda.cern.ch/tasks/?jeditaskid={taskid}&json"
+        r = requests.get(url, timeout=10)
+        r.raise_for_status()
+        data = r.json()
+        return data[0] if isinstance(data, list) and data else None
 
-    Parameters
-    ----------
-    data : dict[str, Any]
-        Task info dictionary from BigPanDA.
+    def _extract_container(self, info: dict) -> str | None:
+        """Find the MC container name within the task information.
 
-    Returns
-    -------
-    str | None
-        The container string if found, otherwise None.
-    """
-    text = json.dumps(data)
-    match = re.search(r"(mc\d+_13TeV\.[\w\.]+)", text)
-    return match.group(1) if match else None
+        Parameters
+        ----------
+        info : dict
+            The task information dictionary from BigPanDA.
 
+        Returns
+        -------
+        str | None
+            The container name (e.g., 'mc16_13TeV...'), or ``None`` if not found.
+        """
+        text = json.dumps(info)
+        m = re.search(r"(mc\d+_13TeV\.[\w\.]+)", text)
+        return m.group(1) if m else None
 
-def parse_line_from_taskname(taskname: str) -> tuple[int | None, str | None]:
-    """Extract DSID and etag from a task name string.
+    def _parse_info(self, container: str) -> tuple[int, str, str] | None:
+        """Parse DSID, etag, and campaign from a container name.
 
-    Parameters
-    ----------
-    taskname : str
-        Full task name.
+        Parameters
+        ----------
+        container : str
+            The full MC container name.
 
-    Returns
-    -------
-    tuple[int | None, str | None]
-        A tuple of (DSID as int, etag as string), or (None, None) if not found.
-    """
-    match = re.match(r".*\.(\d{6})\.e(\d+)_", taskname)
-    if match:
-        dsid, etag = match.groups()
-        return int(dsid), f"e{etag}"
-    return None, None
-
-
-def parse_campaign_from_taskname(taskname: str) -> str | None:
-    """Derive campaign (mc15/mc16/etc.) from a task or container name.
-
-    Parameters
-    ----------
-    taskname : str
-        The name string.
-
-    Returns
-    -------
-    str | None
-        Campaign string, or None if not found.
-    """
-    m = re.match(r"(mc\d+)_13TeV", taskname)
-    if m:
-        raw_campaign = m.group(1)
-        return "mc16" if raw_campaign == "mc20" else raw_campaign
-    return None
-
-
-def extract_info_from_container(container: str) -> tuple[int, str, str] | None:
-    """Extract DSID, etag, and campaign name from a container string.
-
-    Parameters
-    ----------
-    container : str
-        The MC container string.
-
-    Returns
-    -------
-    tuple[int, str, str] | None
-        A tuple of (DSID, etag, campaign), or None if parsing fails.
-    """
-    m_campaign = re.search(r"\b(mc\d+)_13TeV", container)
-    m_dsid = re.search(r"\.(\d{6})\.", container)
-    m_etag = re.search(r"\.e(\d+)(?:[_.]|$)", container)
-    if m_campaign and m_dsid and m_etag:
-        raw_campaign = m_campaign.group(1)
-        campaign = "mc16" if raw_campaign == "mc20" else raw_campaign
-        dsid = int(m_dsid.group(1))
-        etag = f"e{m_etag.group(1)}"
-        return dsid, etag, campaign
-    return None
-
-
-def query_xsecdb(campaign: str, dsid: int, etag: str) -> dict[str, Any] | None:
-    """Look up cross-section metadata in the PMG xsecDB.
-
-    Parameters
-    ----------
-    campaign : str
-        Campaign name (e.g., mc16).
-    dsid : int
-        Dataset ID.
-    etag : str
-        Event tag.
-
-    Returns
-    -------
-    dict[str, Any] | None
-        Dictionary with cross_section_pb, genFiltEff, kfactor, and etag if found, otherwise None.
-    """
-    db_path = XSECDB_MAP.get(campaign)
-    print(f"Searching in {db_path} for DSID={dsid}, etag={etag}")
-    if not db_path or not Path(db_path).exists():
-        print(f"ERROR: Database file for campaign '{campaign}' not found.")
+        Returns
+        -------
+        tuple[int, str, str] | None
+            A tuple of (DSID, etag, campaign), or ``None`` if parsing fails.
+            Note: 'mc20' is automatically mapped to 'mc16'.
+        """
+        mc = re.search(r"\b(mc\d+)_13TeV", container)
+        dsid = re.search(r"\.(\d{6})\.", container)
+        etag = re.search(r"\.e(\d+)(?:[_.]|$)", container)
+        if mc and dsid and etag:
+            campaign = "mc16" if mc.group(1) == "mc20" else mc.group(1)
+            return int(dsid.group(1)), f"e{etag.group(1)}", campaign
         return None
 
-    # Iterate through lines in the DB to find a match
-    with open(db_path) as f:
-        for raw_line in f:
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-            fields = line.split()
-            if len(fields) < 9:
-                continue
-            if str(dsid) == fields[0] and etag == fields[8]:
-                print(f"Match found in {db_path}")
-                return {
-                    "cross_section_pb": float(fields[2]),
-                    "genFiltEff": float(fields[3]),
-                    "kfactor": float(fields[4]),
-                    "etag": fields[8],
-                }
-    print(f"No match found for DSID={dsid}, etag={etag} in {db_path}")
-    return None
+    def _download_db(self, campaign: str) -> str:
+        """Download the PMG database for a specific campaign.
 
+        Parameters
+        ----------
+        campaign : str
+            The MC campaign name (e.g., 'mc16').
 
-def write_metadata_to_h5(h5_filename: str, dsid: int, metadata_dict: dict[str, Any]) -> None:
-    """Write metadata values into an HDF5 file under metadata/<DSID>.
+        Returns
+        -------
+        str
+            The local path to the downloaded database file.
+        """
+        fn = XSECDB_MAP[campaign]
+        url = XSECDB_URL_BASE + fn
+        if not Path(fn).exists():
+            r = requests.get(url, timeout=10)
+            r.raise_for_status()
+            Path(fn).write_bytes(r.content)
+        return fn
 
-    Parameters
-    ----------
-    h5_filename : str
-        Target HDF5 file.
-    dsid : int
-        Dataset ID to write metadata for.
-    metadata_dict : dict[str, Any]
-        Dictionary of metadata to inject.
-    """
-    with h5py.File(h5_filename, "a") as f:
-        meta_group = f.require_group("metadata")
-        dsid_group = meta_group.require_group(str(dsid))
+    def _query_xsecdb(self, campaign: str, dsid: int, etag: str) -> dict | None:
+        """Search the PMG database for metadata matching a DSID and etag.
 
-        # Overwrite existing keys if present
-        for key in ["cross_section_pb", "genFiltEff", "kfactor"]:
-            if key in dsid_group:
-                del dsid_group[key]
-            dsid_group.create_dataset(key, data=metadata_dict[key])
-            print(f"Wrote {key} = {metadata_dict[key]} to metadata/{dsid}/{key}")
+        Parameters
+        ----------
+        campaign : str
+            The MC campaign name.
+        dsid : int
+            Dataset ID.
+        etag : str
+            The AMI tag (e.g., 'e1234').
 
+        Returns
+        -------
+        dict | None
+            Dictionary containing 'cross_section_pb', 'genFiltEff', and 'kfactor',
+            or ``None`` if no matching record is found.
+        """
+        db_path = self._download_db(campaign)
+        with open(db_path) as f:
+            for line in f:
+                if line.startswith("#"):
+                    continue
+                parts = line.split()
+                if len(parts) >= 9 and parts[0] == str(dsid) and parts[8] == etag:
+                    return {
+                        "cross_section_pb": float(parts[2]),
+                        "genFiltEff": float(parts[3]),
+                        "kfactor": float(parts[4]),
+                    }
+        return None
 
-def handle_yaml_fallback(h5_path: Path, yaml_data: dict[str, Any]) -> None:
-    """Use fallback metadata from YAML if automatic lookup fails.
+    def inject_metadata(self) -> None:
+        """Execute the full workflow to inject metadata into the HDF5 file.
 
-    Parameters
-    ----------
-    h5_path : Path
-        Path to the HDF5 file.
-    yaml_data : dict[str, Any]
-        Metadata dictionary loaded from YAML.
-
-    Raises
-    ------
-    ValueError
-        If YAML is invalid, empty, or missing required fields.
-    """
-    if len(yaml_data) != 1:
-        raise ValueError("YAML fallback file must contain exactly one entry")
-
-    key, value = next(iter(yaml_data.items()))
-
-    # YAML may specify container or DSID
-    if key == "container name":
-        if not isinstance(value, str):
-            raise ValueError("'container name' must be a string")
-        container = value
-        print(f"YAML container fallback: {container}")
-        info = extract_info_from_container(container)
+        This method coordinates Task ID extraction, API fetching, DB querying,
+        and final HDF5 attribute writing. Metadata is stored in a group
+        named ``metadata/{dsid}``.
+        """
+        taskid = self._extract_taskid()
+        if not taskid:
+            print(f"No Task ID found in {self.h5_path.name}")
+            return
+        info = self._fetch_taskinfo(taskid)
         if not info:
-            raise ValueError(
-                f"Failed to parse valid DSID / etag / campaign from container: {container}"
-            )
-        dsid, etag, campaign = info
-        meta = query_xsecdb(campaign, dsid, etag)
+            print("No BigPanDA info found.")
+            return
+        container = self._extract_container(info)
+
+        if not container:
+            print("Failed to extract container name from BigPanDA info.")
+            return
+
+        parsed = self._parse_info(container)
+        if not parsed:
+            print("Failed to parse DSID/etag/campaign.")
+            return
+        dsid, etag, campaign = parsed
+        meta = self._query_xsecdb(campaign, dsid, etag)
         if not meta:
-            raise ValueError(f"Container not found in PMG database: {container}")
-    else:
-        try:
-            dsid = int(key)
-        except ValueError as e:
-            raise ValueError("YAML key must be a valid DSID or 'container name'") from e
-        meta = value
-        required_keys = {"cross_section_pb", "genFiltEff", "kfactor"}
-        if not isinstance(meta, dict) or not required_keys.issubset(meta):
-            raise ValueError(
-                "Manual metadata must include: cross_section_pb / genFiltEff / kfactor"
-            )
-
-    write_metadata_to_h5(str(h5_path), dsid, meta)
-    print(f"YAML metadata written to {h5_path.name} for DSID {dsid}")
-
-
-def parse_args_and_yaml() -> tuple[list[str], dict[str, Any]]:
-    """Parse CLI arguments and load YAML metadata if provided.
-
-    Returns
-    -------
-    tuple[list[str], dict[str, Any]]
-        A tuple of (list of HDF5 file paths, YAML metadata dict).
-    """
-    parser = argparse.ArgumentParser(
-        description="Inject metadata into .h5 files via BigPanDA or YAML fallback."
-    )
-    parser.add_argument("h5_files", nargs="+", help="List of .h5 files")
-    parser.add_argument("-m", "--manual-yaml", help="Manual metadata YAML fallback file")
-    args = parser.parse_args()
-
-    yaml_data: dict[str, Any] = {}
-    if args.manual_yaml:
-        with open(args.manual_yaml) as f:
-            yaml_data = yaml.safe_load(f)
-
-    return args.h5_files, yaml_data
-
-
-def process_single_file(path: Path, yaml_data: dict[str, Any]) -> None:
-    """Process a single .h5 file by attempting BigPanDA lookup, then fallback to YAML.
-
-    Parameters
-    ----------
-    path : Path
-        Path to the HDF5 file.
-    yaml_data : dict[str, Any]
-        Optional fallback metadata.
-    """
-    if not path.exists():
-        print(f"File not found: {path}")
-        return
-
-    taskid = extract_taskid_from_filename(path)
-    if taskid:
-        print(f"Extracted Task ID: {taskid}")
-        taskinfo = fetch_taskinfo_from_bigpanda(taskid)
-        if taskinfo:
-            taskname = taskinfo.get("taskname", "")
-            dsid, etag = parse_line_from_taskname(taskname)
-            container = extract_mc_container_from_json(taskinfo)
-            campaign = parse_campaign_from_taskname(container or "")
-
-            # Only query DB if all three are found
-            if dsid and etag and campaign:
-                print(
-                    f"Matched info: DSID={dsid}, etag={etag}, "
-                    f"campaign={campaign}, container={container}"
-                )
-                meta = query_xsecdb(campaign, dsid, etag)
-                if meta:
-                    meta["campaign"] = campaign
-                    print(
-                        f"Got metadata: cross_section = {meta['cross_section_pb']} pb, "
-                        f"eff = {meta['genFiltEff']}, k = {meta['kfactor']}"
-                    )
-                    try:
-                        write_metadata_to_h5(str(path), dsid, meta)
-                        print(f"Metadata written to {path.name}")
-                    except (OSError, ValueError) as e:
-                        print(f"Failed to write metadata: {e}")
-                    else:
-                        return
-    else:
-        print("Failed to extract Task ID from filename")
-
-    # Fallback to YAML if automatic mode fails
-    if yaml_data:
-        try:
-            print("Using YAML fallback path")
-            handle_yaml_fallback(path, yaml_data)
-        except (ValueError, KeyError, OSError) as e:
-            print(f"YAML fallback failed: {e}")
-    else:
-        print("Failed to retrieve metadata and no YAML fallback provided")
-
-
-def main() -> None:
-    """Entry point: parse arguments, download xsecDBs, process each file, and clean up."""
-    h5_files, yaml_data = parse_args_and_yaml()
-    download_xsecdb_files()
-
-    for h5_file in h5_files:
-        print(f"\n==================== Processing {h5_file} ====================\n")
-        process_single_file(Path(h5_file), yaml_data)
-
-    # Remove temporary database files after use
-    for filename in XSECDB_MAP.values():
-        path = Path(filename)
-        if path.exists():
-            try:
-                path.unlink()
-                print(f"Deleted temporary file: {filename}")
-            except OSError as e:
-                print(f"Failed to delete {filename}: {e}")
-
-
-if __name__ == "__main__":
-    main()
+            print("No metadata found in PMG DB.")
+            return
+        with h5py.File(self.h5_path, "a") as f:
+            g = f.require_group(f"metadata/{dsid}")
+            for k, v in meta.items():
+                if k in g:
+                    del g[k]
+                g.create_dataset(k, data=v)
+        print(f"Metadata injected for {self.h5_path.name}")

--- a/ftag/find_metadata.py
+++ b/ftag/find_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import re
 from pathlib import Path
@@ -189,3 +190,23 @@ class MetadataFinder:
                     del g[k]
                 g.create_dataset(k, data=v)
         print(f"Metadata injected for {self.h5_path.name}")
+
+
+def main() -> None:
+    """Command line entry point to fetch and inject PMG metadata."""
+    parser = argparse.ArgumentParser(description="Fetch and inject PMG metadata into HDF5 files.")
+    parser.add_argument(
+        "h5_paths", nargs="+", type=str, help="Path(s) to the HDF5 file(s) to process."
+    )
+
+    args = parser.parse_args()
+
+    # Process each provided HDF5 file
+    for h5_path in args.h5_paths:
+        print(f"Processing: {h5_path}")
+        finder = MetadataFinder(h5_path)
+        finder.inject_metadata()
+
+
+if __name__ == "__main__":
+    main()

--- a/ftag/tests/test_find_metadata.py
+++ b/ftag/tests/test_find_metadata.py
@@ -182,3 +182,15 @@ class TestMetadataFinder:
         ):
             finder.inject_metadata()
             assert "No metadata found in PMG DB" in capsys.readouterr().out
+
+    def test_inject_metadata_no_container(self, mock_h5, capsys):
+        """Cover the specific branch: if not container."""
+        finder = MetadataFinder(mock_h5)
+        with (
+            patch.object(finder, "_extract_taskid", return_value="12345678"),
+            patch.object(finder, "_fetch_taskinfo", return_value={"some": "info"}),
+            patch.object(finder, "_extract_container", return_value=None),
+        ):
+            finder.inject_metadata()
+            captured = capsys.readouterr()
+            assert "Failed to extract container name" in captured.out

--- a/ftag/tests/test_find_metadata.py
+++ b/ftag/tests/test_find_metadata.py
@@ -1,424 +1,184 @@
+# ruff: noqa: SLF001
 from __future__ import annotations
 
-import json
-import tempfile
-import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import h5py
-import requests
-import yaml
+import pytest
 
-from ftag import find_metadata
+from ftag.find_metadata import MetadataFinder
+
+# === 1. Mock Data Setup ===
+
+# Ensure etag is in the 9th column (index 8) to satisfy len(parts) >= 9
+# Format: DSID  Name  Xsec  Eff  k  ?  ?  ?  etag
+MOCK_XSEC_LINE = "601229  Pythia8_jetjet  0.015  1.0  1.1  0.0  x  x  e8514\n"
+
+MOCK_PANDA_INFO = [
+    {
+        "jeditaskid": 12345678,
+        "taskname": "mc23_13TeV.601229.PhPy8.e8514_s4162/",
+    }
+]
 
 
-class TestFindMetadata(unittest.TestCase):
-    #
-    # === 1. TaskID/Container/Campaign Extraction Functions ===
-    #
-    def test_extract_taskid_from_filename(self):
-        self.assertEqual(
-            find_metadata.extract_taskid_from_filename(Path("user.test.12345678._000001.h5")),
-            "12345678",
-        )
+@pytest.fixture
+def mock_h5(tmp_path: Path) -> Path:
+    p = tmp_path / "user.test.12345678.output.h5"
+    with h5py.File(p, "w") as f:
+        f.create_group("metadata")
+    return p
 
-    def test_extract_taskid_fail(self):
-        self.assertIsNone(find_metadata.extract_taskid_from_filename(Path("badname.h5")))
 
-    def test_parse_line_from_taskname(self):
-        dsid, etag = find_metadata.parse_line_from_taskname("user.123456.e1234_tid123")
-        self.assertEqual((dsid, etag), (123456, "e1234"))
+# === 2. Test Class ===
 
-    def test_parse_line_from_taskname_fail(self):
-        self.assertEqual(find_metadata.parse_line_from_taskname("not.match"), (None, None))
 
-    def test_parse_campaign(self):
-        self.assertEqual(find_metadata.parse_campaign_from_taskname("mc20_13TeV"), "mc16")
-        self.assertEqual(find_metadata.parse_campaign_from_taskname("mc21_13TeV"), "mc21")
-        self.assertIsNone(find_metadata.parse_campaign_from_taskname("data18"))
+class TestMetadataFinder:
+    # --- Basic Parsing Tests ---
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("user.test.12345678._000001.h5", "12345678"),
+            ("mc23.11040412.h5", "11040412"),
+            ("no_id_here.h5", None),
+        ],
+    )
+    def test_extract_taskid(self, tmp_path, filename, expected):
+        p = tmp_path / filename
+        finder = MetadataFinder(p)
+        assert finder._extract_taskid() == expected
 
-    def test_extract_info_from_container(self):
-        self.assertEqual(
-            find_metadata.extract_info_from_container("mc20_13TeV.123456.e7890_s1234_r5678"),
-            (123456, "e7890", "mc16"),
-        )
-        self.assertIsNone(find_metadata.extract_info_from_container("bad.container"))
+    @pytest.mark.parametrize(
+        ("container", "expected"),
+        [
+            ("mc20_13TeV.123456.e7890", (123456, "e7890", "mc16")),
+            ("mc23_13TeV.601229.e8514", (601229, "e8514", "mc23")),
+            ("bad.name", None),
+        ],
+    )
+    def test_parse_info(self, mock_h5, container, expected):
+        finder = MetadataFinder(mock_h5)
+        result = finder._parse_info(container)
+        assert result == expected
 
-    def test_extract_mc_container_from_json(self):
-        data = {"key": "mc21_13TeV.123456.e3456_s2345"}
-        self.assertIn("mc21_13TeV", find_metadata.extract_mc_container_from_json(data))
-        self.assertIsNone(find_metadata.extract_mc_container_from_json({"no": "match"}))
+    # --- Network and Database Logic Tests ---
+    @patch("requests.get")
+    def test_fetch_taskinfo_success(self, mock_get, mock_h5):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = MOCK_PANDA_INFO
+        finder = MetadataFinder(mock_h5)
+        info = finder._fetch_taskinfo("12345678")
+        assert info["jeditaskid"] == 12345678
 
-    #
-    # === 2. URL Validation ===
-    #
-    def test_validate_url_scheme(self):
-        self.assertIsNotNone(find_metadata.validate_url_scheme("https://abc.com"))
-        with self.assertRaises(ValueError):
-            find_metadata.validate_url_scheme("ftp://bad")
+    @patch("requests.get")
+    def test_fetch_taskinfo_empty(self, mock_get, mock_h5):
+        """Cover the branch where _fetch_taskinfo returns None."""
+        mock_get.return_value.json.return_value = []
+        finder = MetadataFinder(mock_h5)
+        assert finder._fetch_taskinfo("12345") is None
 
-    #
-    # === 3. Xsec Database Download Logic ===
-    #
-    def test_download_xsecdb_files_invalid_scheme(self):
+    def test_query_xsecdb_logic(self, mock_h5, tmp_path):
+        """Test the normal query logic (fixes the 9-column data issue)."""
+        db_file = tmp_path / "PMGxsecDB_mc23.txt"
+        db_file.write_text("# comment\n" + MOCK_XSEC_LINE)
+
+        finder = MetadataFinder(mock_h5)
+        with patch.object(finder, "_download_db", return_value=str(db_file)):
+            meta = finder._query_xsecdb("mc23", 601229, "e8514")
+            assert meta["cross_section_pb"] == 0.015
+            assert meta["genFiltEff"] == 1.0
+
+    def test_query_xsecdb_not_found(self, mock_h5, tmp_path):
+        """Cover branch where _query_xsecdb returns None when no data is found."""
+        db_file = tmp_path / "PMGxsecDB_mc23.txt"
+        db_file.write_text(MOCK_XSEC_LINE)
+        finder = MetadataFinder(mock_h5)
+        with patch.object(finder, "_download_db", return_value=str(db_file)):
+            # DSID matches but etag does not
+            assert finder._query_xsecdb("mc23", 601229, "wrong_etag") is None
+
+    # --- Core Injection Flow Tests ---
+    @patch("requests.get")
+    def test_inject_metadata_full_chain(self, mock_get, mock_h5, tmp_path):
+        """Test complete successful injection chain, ensuring HDF5 write is covered."""
+        # Mock BigPanDA response
+        mock_panda_resp = MagicMock()
+        mock_panda_resp.json.return_value = MOCK_PANDA_INFO
+
+        # Mock DB download response
+        mock_db_resp = MagicMock()
+        mock_db_resp.content = MOCK_XSEC_LINE.encode()
+
+        mock_get.side_effect = [mock_panda_resp, mock_db_resp]
+
+        # Let the file actually be written to pytest's auto-cleaned temporary directory
+        db_file = tmp_path / "PMGxsecDB_mc23.txt"
+
+        with patch.dict("ftag.find_metadata.XSECDB_MAP", {"mc23": str(db_file)}):
+            finder = MetadataFinder(mock_h5)
+            finder.inject_metadata()
+
+        # Verify results
+        with h5py.File(mock_h5, "r") as f:
+            assert "metadata/601229/cross_section_pb" in f
+            assert f["metadata/601229/cross_section_pb"][()] == 0.015
+
+    def test_inject_metadata_overwrite(self, mock_h5):
+        """Ensure the overwrite logic 'if k in g: del g[k]' is executed."""
+        dsid = 601229
+        with h5py.File(mock_h5, "a") as f:
+            g = f.require_group(f"metadata/{dsid}")
+            g.create_dataset("cross_section_pb", data=999.0)
+
+        finder = MetadataFinder(mock_h5)
+        mock_meta = {"cross_section_pb": 0.015}
+
+        # Mock prerequisite steps to directly test the injection part
         with (
-            patch("ftag.find_metadata.Path.exists", return_value=False),
-            patch("ftag.find_metadata.validate_url_scheme", side_effect=ValueError("bad")),
-            patch("ftag.find_metadata.requests.get"),
+            patch.object(finder, "_extract_taskid", return_value="12"),
+            patch.object(finder, "_fetch_taskinfo", return_value={"t": "m"}),
+            patch.object(finder, "_extract_container", return_value="mc23_13TeV.601229.e8514"),
+            patch.object(finder, "_query_xsecdb", return_value=mock_meta),
         ):
-            find_metadata.download_xsecdb_files()
+            finder.inject_metadata()
 
-    def test_download_xsecdb_files_network_fail(self):
+        with h5py.File(mock_h5, "r") as f:
+            assert f[f"metadata/{dsid}/cross_section_pb"][()] == 0.015
+
+    # --- Exception Branch Tests ---
+    def test_inject_metadata_fail_branches(self, mock_h5, capsys):
+        finder = MetadataFinder(mock_h5)
+
+        # 1. No TaskID
+        with patch.object(finder, "_extract_taskid", return_value=None):
+            finder.inject_metadata()
+            assert "No Task ID found" in capsys.readouterr().out
+
+        # 2. No task info
         with (
-            patch("ftag.find_metadata.Path.exists", return_value=False),
-            patch("ftag.find_metadata.requests.get", side_effect=requests.RequestException("fail")),
+            patch.object(finder, "_extract_taskid", return_value="12345678"),
+            patch.object(finder, "_fetch_taskinfo", return_value=None),
         ):
-            find_metadata.download_xsecdb_files()
+            finder.inject_metadata()
+            assert "No BigPanDA info found" in capsys.readouterr().out
 
-    def test_download_xsecdb_files_success(self):
+        # 3. Container parsing failed
         with (
-            patch("ftag.find_metadata.Path.exists", return_value=False),
-            patch("ftag.find_metadata.validate_url_scheme") as mock_validate,
-            patch("ftag.find_metadata.requests.get") as mock_get,
-            patch("ftag.find_metadata.Path.write_bytes") as mock_write,
-            patch("builtins.print") as mock_print,
+            patch.object(finder, "_extract_taskid", return_value="12"),
+            patch.object(finder, "_fetch_taskinfo", return_value={"t": "m"}),
+            patch.object(finder, "_extract_container", return_value="invalid"),
+            patch.object(finder, "_parse_info", return_value=None),
         ):
-            mock_response = MagicMock()
-            mock_response.status_code = 200
-            mock_response.content = b"mock file content"
-            mock_get.return_value = mock_response
+            finder.inject_metadata()
+            assert "Failed to parse DSID" in capsys.readouterr().out
 
-            find_metadata.download_xsecdb_files()
-
-            self.assertTrue(mock_validate.called)
-            self.assertTrue(mock_get.called)
-            self.assertTrue(mock_response.raise_for_status.called)
-            self.assertTrue(mock_write.called)
-            mock_print.assert_any_call("Downloaded: PMGxsecDB_mc15.txt")
-
-    #
-    # === 4. BigPanDA Query ===
-    #
-    def test_fetch_taskinfo_success(self):
-        mock_data = [
-            {"taskname": "user.123456.e7890_tid123", "inputdataset": "mc20_13TeV.123456.e7890"}
-        ]
-        with patch("ftag.find_metadata.requests.get") as mock_get:
-            mock_get.return_value.status_code = 200
-            mock_get.return_value.json.return_value = mock_data
-            out = find_metadata.fetch_taskinfo_from_bigpanda("12345678")
-            self.assertEqual(out, mock_data[0])
-
-    def test_fetch_taskinfo_empty(self):
-        with patch("ftag.find_metadata.requests.get") as mock_get:
-            mock_get.return_value.status_code = 200
-            mock_get.return_value.json.return_value = []
-            self.assertIsNone(find_metadata.fetch_taskinfo_from_bigpanda("123"))
-
-    def test_fetch_taskinfo_jsonfail(self):
-        with patch("ftag.find_metadata.requests.get") as mock_get:
-            mock_get.return_value.status_code = 200
-            mock_get.return_value.json.side_effect = json.JSONDecodeError("fail", "doc", 0)
-            self.assertIsNone(find_metadata.fetch_taskinfo_from_bigpanda("123"))
-
-    #
-    # === 5. Xsec Database Query ===
-    #
-    def test_query_xsecdb(self):
-        line = "123456 x 2.2 0.9 1.1 x x x e9999\n"
-        with tempfile.NamedTemporaryFile("w+", delete=False) as f:
-            f.write(line)
-            f.flush()
-            with patch("ftag.find_metadata.XSECDB_MAP", {"mc16": f.name}):
-                r = find_metadata.query_xsecdb("mc16", 123456, "e9999")
-                self.assertEqual(r["cross_section_pb"], 2.2)
-                self.assertEqual(r["genFiltEff"], 0.9)
-                self.assertEqual(r["kfactor"], 1.1)
-
-    def test_query_xsecdb_invalid_line(self):
-        line = "123456 a b\n"
-        with tempfile.NamedTemporaryFile("w+", delete=False) as f:
-            f.write(line)
-            f.flush()
-            with patch("ftag.find_metadata.XSECDB_MAP", {"mc16": f.name}):
-                r = find_metadata.query_xsecdb("mc16", 123456, "e0000")
-                self.assertIsNone(r)
-
-    def test_query_xsecdb_dbfile_missing(self):
+        # 4. No result in database
         with (
-            patch("ftag.find_metadata.Path.exists", return_value=False),
-            patch("builtins.print") as mock_print,
+            patch.object(finder, "_extract_taskid", return_value="12"),
+            patch.object(finder, "_fetch_taskinfo", return_value={"t": "m"}),
+            patch.object(finder, "_extract_container", return_value="mc23_13TeV.601229.e8514"),
+            patch.object(finder, "_query_xsecdb", return_value=None),
         ):
-            r1 = find_metadata.query_xsecdb("unknown_campaign", 123456, "e1234")
-            self.assertIsNone(r1)
-            with patch("ftag.find_metadata.XSECDB_MAP", {"mc16": "nonexistent_file.txt"}):
-                r2 = find_metadata.query_xsecdb("mc16", 123456, "e1234")
-                self.assertIsNone(r2)
-            mock_print.assert_any_call(
-                "ERROR: Database file for campaign 'unknown_campaign' not found."
-            )
-            mock_print.assert_any_call("ERROR: Database file for campaign 'mc16' not found.")
-
-    def test_query_xsecdb_skips_comment_and_blank_lines(self):
-        content = "\n# comment line\n123456 x 2.2 0.9 1.1 x x x e1234\n"
-        with tempfile.NamedTemporaryFile("w+", delete=False) as f:
-            f.write(content)
-            f.flush()
-            with patch("ftag.find_metadata.XSECDB_MAP", {"mc16": f.name}):
-                result = find_metadata.query_xsecdb("mc16", 123456, "e1234")
-                self.assertIsNotNone(result)
-                self.assertEqual(result["cross_section_pb"], 2.2)
-                self.assertEqual(result["genFiltEff"], 0.9)
-                self.assertEqual(result["kfactor"], 1.1)
-
-    #
-    # === 6. Metadata Writing ===
-    #
-    def test_write_metadata_to_h5(self):
-        meta = {"cross_section_pb": 2.1, "genFiltEff": 0.5, "kfactor": 1.3}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            find_metadata.write_metadata_to_h5(f.name, 123456, meta)
-            with h5py.File(f.name, "r") as h5:
-                g = h5["metadata/123456"]
-                self.assertEqual(g["cross_section_pb"][()], 2.1)
-
-    def test_write_metadata_overwrites_existing_keys(self):
-        meta1 = {"cross_section_pb": 1.0, "genFiltEff": 0.5, "kfactor": 1.1}
-        meta2 = {"cross_section_pb": 2.0, "genFiltEff": 0.6, "kfactor": 1.2}
-
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            find_metadata.write_metadata_to_h5(f.name, 123456, meta1)
-            find_metadata.write_metadata_to_h5(f.name, 123456, meta2)
-
-            with h5py.File(f.name, "r") as h5:
-                g = h5["metadata/123456"]
-                self.assertEqual(g["cross_section_pb"][()], 2.0)
-                self.assertEqual(g["genFiltEff"][()], 0.6)
-                self.assertEqual(g["kfactor"][()], 1.2)
-
-    #
-    # === 7. YAML Fallback Path ===
-    #
-    def test_handle_yaml_fallback_manual(self):
-        data = {"123456": {"cross_section_pb": 1, "genFiltEff": 1, "kfactor": 1}}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            find_metadata.handle_yaml_fallback(Path(f.name), data)
-            with h5py.File(f.name, "r") as h5:
-                self.assertIn("123456", h5["metadata"])
-
-    def test_handle_yaml_fallback_container_parse_fail(self):
-        data = {"container name": "bad.container.name"}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), data)
-            self.assertIn("Failed to parse valid DSID", str(ctx.exception))
-
-    def test_handle_yaml_fallback_container_not_in_db(self):
-        container = "mc21_13TeV.123456.e7890_s1234_r5678"
-        data = {"container name": container}
-        with (
-            tempfile.NamedTemporaryFile(suffix=".h5") as f,
-            patch(
-                "ftag.find_metadata.extract_info_from_container",
-                return_value=(123456, "e7890", "mc21"),
-            ),
-            patch("ftag.find_metadata.query_xsecdb", return_value=None),
-        ):
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), data)
-            self.assertIn("Container not found", str(ctx.exception))
-
-    def test_handle_yaml_fallback_multiple_entries_raises(self):
-        bad_yaml = {
-            "123456": {"cross_section_pb": 1, "genFiltEff": 1, "kfactor": 1},
-            "123457": {"cross_section_pb": 2, "genFiltEff": 2, "kfactor": 2},
-        }
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), bad_yaml)
-            self.assertIn("YAML fallback file must contain exactly one entry", str(ctx.exception))
-
-    def test_handle_yaml_fallback_empty_yaml_raises(self):
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), {})
-            self.assertIn("YAML fallback file must contain exactly one entry", str(ctx.exception))
-
-    def test_handle_yaml_fallback_container_not_string(self):
-        bad_yaml = {"container name": ["not", "a", "string"]}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), bad_yaml)
-            self.assertIn("'container name' must be a string", str(ctx.exception))
-
-    def test_handle_yaml_fallback_invalid_dsid_key_raises(self):
-        bad_yaml = {"not_a_dsid": {"cross_section_pb": 1, "genFiltEff": 1, "kfactor": 1}}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), bad_yaml)
-            self.assertIn("YAML key must be a valid DSID or 'container name'", str(ctx.exception))
-
-    def test_handle_yaml_fallback_manual_missing_keys(self):
-        bad_yaml = {"123456": {"cross_section_pb": 0.1, "genFiltEff": 0.9}}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), bad_yaml)
-            self.assertIn("Manual metadata must include", str(ctx.exception))
-
-    def test_handle_yaml_fallback_manual_not_dict(self):
-        bad_yaml = {"123456": "this is not a dict"}
-        with tempfile.NamedTemporaryFile(suffix=".h5") as f:
-            with self.assertRaises(ValueError) as ctx:
-                find_metadata.handle_yaml_fallback(Path(f.name), bad_yaml)
-            self.assertIn("Manual metadata must include", str(ctx.exception))
-
-    #
-    # === 8. CLI Argument Parsing ===
-    #
-    def test_parse_args_and_yaml_no_fallback(self):
-        test_args = ["find_metadata.py", "a.h5", "b.h5"]
-        with patch("sys.argv", test_args):
-            h5_files, yaml_data = find_metadata.parse_args_and_yaml()
-            self.assertEqual(h5_files, ["a.h5", "b.h5"])
-            self.assertEqual(yaml_data, {})
-
-    def test_parse_args_and_yaml_with_fallback(self):
-        test_yaml = {"123456": {"cross_section_pb": 1.1, "genFiltEff": 0.9, "kfactor": 1.0}}
-        with tempfile.NamedTemporaryFile("w+", suffix=".yaml", delete=False) as tmp_yaml:
-            yaml.dump(test_yaml, tmp_yaml)
-            tmp_yaml_path = tmp_yaml.name
-        test_args = ["find_metadata.py", "file1.h5", "-m", tmp_yaml_path]
-        with patch("sys.argv", test_args):
-            h5_files, yaml_data = find_metadata.parse_args_and_yaml()
-            self.assertEqual(h5_files, ["file1.h5"])
-            self.assertEqual(yaml_data, test_yaml)
-
-    #
-    # === 9. Main Flow/Integration Tests ===
-    #
-    def test_main_cli_path(self):
-        with (
-            patch("ftag.find_metadata.parse_args_and_yaml", return_value=(["a.h5"], {})),
-            patch("ftag.find_metadata.download_xsecdb_files"),
-            patch("ftag.find_metadata.process_single_file"),
-            patch("ftag.find_metadata.Path.exists", return_value=True),
-            patch("ftag.find_metadata.Path.unlink", side_effect=OSError("fail")),
-        ):
-            find_metadata.main()
-
-    def test_process_single_file_auto_success(self):
-        mock_taskinfo = {
-            "taskname": "user.123456.e7890_tid123",
-            "inputdataset": "mc20_13TeV.123456.e7890_s1234_r5678",
-        }
-        meta = {"cross_section_pb": 3.0, "genFiltEff": 0.5, "kfactor": 1.2, "etag": "e7890"}
-        with (
-            tempfile.NamedTemporaryFile(suffix=".h5") as f,
-            patch("ftag.find_metadata.Path.exists", return_value=True),
-            patch("ftag.find_metadata.extract_taskid_from_filename", return_value="12345678"),
-            patch("ftag.find_metadata.fetch_taskinfo_from_bigpanda", return_value=mock_taskinfo),
-            patch("ftag.find_metadata.parse_line_from_taskname", return_value=(123456, "e7890")),
-            patch(
-                "ftag.find_metadata.extract_mc_container_from_json",
-                return_value=mock_taskinfo["inputdataset"],
-            ),
-            patch("ftag.find_metadata.parse_campaign_from_taskname", return_value="mc16"),
-            patch("ftag.find_metadata.query_xsecdb", return_value=meta.copy()),
-            patch("ftag.find_metadata.write_metadata_to_h5") as mock_write,
-            patch("builtins.print") as mock_print,
-        ):
-            find_metadata.process_single_file(Path(f.name), yaml_data={})
-            mock_write.assert_called_once_with(str(f.name), 123456, {**meta, "campaign": "mc16"})
-            mock_print.assert_any_call("Extracted Task ID: 12345678")
-
-    def test_process_single_file_yaml_fallback_fails(self):
-        path = Path("some.12345678._000001.h5")
-        yaml_data = {"container name": "bad.container"}
-        with (
-            patch("ftag.find_metadata.Path.exists", return_value=True),
-            patch("ftag.find_metadata.extract_taskid_from_filename", return_value=None),
-            patch("builtins.print") as mock_print,
-        ):
-            find_metadata.process_single_file(path, yaml_data)
-            mock_print.assert_any_call("Using YAML fallback path")
-            self.assertTrue(
-                any("YAML fallback failed:" in c[0][0] for c in mock_print.call_args_list)
-            )
-
-    def test_process_single_file_no_taskid_no_fallback(self):
-        path = Path("noid.h5")
-        with (
-            patch("ftag.find_metadata.Path.exists", return_value=True),
-            patch("ftag.find_metadata.extract_taskid_from_filename", return_value=None),
-            patch("builtins.print") as mock_print,
-        ):
-            find_metadata.process_single_file(path, yaml_data={})
-            mock_print.assert_any_call("Failed to retrieve metadata and no YAML fallback provided")
-
-    def test_process_single_file_path_not_exists(self):
-        fake_path = Path("nonexistent_file.h5")
-        with (
-            patch("ftag.find_metadata.Path.exists", return_value=False),
-            patch("builtins.print") as mock_print,
-            patch("ftag.find_metadata.extract_taskid_from_filename") as mock_extract,
-            patch("ftag.find_metadata.fetch_taskinfo_from_bigpanda") as mock_fetch,
-        ):
-            find_metadata.process_single_file(fake_path, yaml_data={})
-            mock_print.assert_any_call(f"File not found: {fake_path}")
-            mock_extract.assert_not_called()
-            mock_fetch.assert_not_called()
-
-    def test_process_single_file_write_metadata_fails(self):
-        mock_taskinfo = {
-            "taskname": "user.123456.e7890_tid123",
-            "inputdataset": "mc20_13TeV.123456.e7890_s1234_r5678",
-        }
-        meta = {"cross_section_pb": 1.0, "genFiltEff": 1.0, "kfactor": 1.0, "etag": "e7890"}
-
-        with (
-            tempfile.NamedTemporaryFile(suffix=".h5") as f,
-            patch("ftag.find_metadata.Path.exists", return_value=True),
-            patch("ftag.find_metadata.extract_taskid_from_filename", return_value="12345678"),
-            patch("ftag.find_metadata.fetch_taskinfo_from_bigpanda", return_value=mock_taskinfo),
-            patch("ftag.find_metadata.parse_line_from_taskname", return_value=(123456, "e7890")),
-            patch(
-                "ftag.find_metadata.extract_mc_container_from_json",
-                return_value=mock_taskinfo["inputdataset"],
-            ),
-            patch("ftag.find_metadata.parse_campaign_from_taskname", return_value="mc16"),
-            patch("ftag.find_metadata.query_xsecdb", return_value=meta),
-            patch(
-                "ftag.find_metadata.write_metadata_to_h5",
-                side_effect=OSError("simulated write failure"),
-            ),
-            patch("builtins.print") as mock_print,
-        ):
-            find_metadata.process_single_file(Path(f.name), yaml_data={})
-            self.assertTrue(
-                any(
-                    "Failed to write metadata: simulated write failure" in call.args[0]
-                    for call in mock_print.call_args_list
-                )
-            )
-
-    def test_main_deletes_tempfile_success(self):
-        with (
-            patch("ftag.find_metadata.parse_args_and_yaml", return_value=(["a.h5"], {})),
-            patch("ftag.find_metadata.download_xsecdb_files"),
-            patch("ftag.find_metadata.process_single_file"),
-            patch("ftag.find_metadata.Path.exists", return_value=True),
-            patch("ftag.find_metadata.Path.unlink"),
-            patch("builtins.print") as mock_print,
-        ):
-            find_metadata.main()
-            calls = [
-                f"Deleted temporary file: {Path(name)}"
-                for name in find_metadata.XSECDB_MAP.values()
-            ]
-            for c in calls:
-                assert any(c in p.args[0] for p in mock_print.call_args_list)
-
-
-if __name__ == "__main__":
-    unittest.main()
+            finder.inject_metadata()
+            assert "No metadata found in PMG DB" in capsys.readouterr().out

--- a/ftag/tests/test_find_metadata.py
+++ b/ftag/tests/test_find_metadata.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import h5py
 import pytest
 
-from ftag.find_metadata import MetadataFinder
+from ftag.find_metadata import MetadataFinder, main
 
 # === 1. Mock Data Setup ===
 
@@ -194,3 +194,27 @@ class TestMetadataFinder:
             finder.inject_metadata()
             captured = capsys.readouterr()
             assert "Failed to extract container name" in captured.out
+
+    # --- CLI Entry Point Test ---
+    @patch("sys.argv", ["find_metadata.py", "test_file_1.h5", "test_file_2.h5"])
+    @patch("ftag.find_metadata.MetadataFinder")
+    def test_main_block(self, mock_finder_class, capsys):
+        """Test the command-line execution block via the main() function."""
+        # Setup the mock instance returned when MetadataFinder is instantiated
+        mock_instance = mock_finder_class.return_value
+
+        # Call the main function directly
+        main()
+
+        # Verify stdout prints
+        captured = capsys.readouterr()
+        assert "Processing: test_file_1.h5" in captured.out
+        assert "Processing: test_file_2.h5" in captured.out
+
+        # Verify MetadataFinder was instantiated with correct arguments
+        assert mock_finder_class.call_count == 2
+        mock_finder_class.assert_any_call("test_file_1.h5")
+        mock_finder_class.assert_any_call("test_file_2.h5")
+
+        # Verify the injection method was triggered for each provided file
+        assert mock_instance.inject_metadata.call_count == 2

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -258,6 +258,15 @@ def test_get_virtual_layout(test_h5_files):
     assert layout.dtype == np.dtype("int64")
 
 
+def test_get_virtual_layout_raises_type_error(tmp_path):
+    bad_file = tmp_path / "bad_structure.h5"
+    with h5py.File(bad_file, "w") as f:
+        f.create_group("not_a_dataset")
+
+    with pytest.raises(TypeError, match="is a Group, but a Dataset is required for VDS"):
+        get_virtual_layout([str(bad_file)], "not_a_dataset")
+
+
 def test_create_virtual_file(test_h5_files):
     with tempfile.NamedTemporaryFile() as tmpfile:
         pattern = Path(test_h5_files[0]).parent / "test_file_*"

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -64,6 +64,11 @@ def get_virtual_layout(fnames: list[str], group: str) -> h5py.VirtualLayout:
     -------
     h5py.VirtualLayout
         Virtual layout of the new virtual dataset
+
+    Raises
+    ------
+    TypeError
+        If the target path in any input file is a Group instead of a Dataset.
     """
     sources = []
     total = 0
@@ -71,8 +76,16 @@ def get_virtual_layout(fnames: list[str], group: str) -> h5py.VirtualLayout:
     # Loop over the input files
     for fname in fnames:
         with h5py.File(fname, "r") as f:
-            # Get the file and append its length
-            vsrc = h5py.VirtualSource(f[group])
+            target = f[group]
+
+            # If this is a Group instead of a Dataset, VDS cannot create a layout for it directly.
+            # However, UPP usually passes specific dataset paths.
+            if not isinstance(target, h5py.Dataset):
+                msg = f"'{group}' in {fname} is a Group, but a Dataset is required for VDS."
+                raise TypeError(msg)
+
+            # Explicitly use the path and name, while passing the exact shape.
+            vsrc = h5py.VirtualSource(fname, group, shape=target.shape)
             total += vsrc.shape[0]
             sources.append(vsrc)
 
@@ -330,6 +343,7 @@ def create_virtual_file(
             common_groups = groups if not common_groups else common_groups & groups
 
     # Ditch the bookkeeper. We will process it separately
+    common_groups.discard("metadata")
     common_groups.discard("cutBookkeeper")
 
     # Check that the directory of the output file exists


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* **Refactored `find_metadata.py` into a tool designed for UPP**: Transitioned the standalone script into a formal `MetadataFinder` class structure to improve modularity and enable easier integration within the `ftag` library.


## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)