### PR TITLE
Fix CLI entrypoints and vds regex option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Fix CLI entry points and `vds` regex option handling [#158](https://github.com/umami-hep/atlas-ftag-tools/pull/158)
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
 - Refactored `find_metadata.py` into a formal `MetadataFinder` class to improve modularity and facilitate integration with the ftag library for UPP. [#153](https://github.com/umami-hep/atlas-ftag-tools/pull/153)
 

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -373,21 +373,3 @@ def test_main():
             assert key == "data"
             assert f[key].shape == (30,)
             assert f[key].attrs["key"] == "value"
-
-
-def test_main_regex_hyphenated_alias_defaults_to_cwd(monkeypatch, tmp_path):
-    """Test documented regex option spelling and default regex directory."""
-    for i in range(3):
-        fname = tmp_path / f"test_{i}.h5"
-        with h5py.File(fname, "w") as f:
-            f.create_dataset("data", data=[i] * 5)
-
-    monkeypatch.chdir(tmp_path)
-    output_fname = tmp_path / "out.h5"
-
-    main([r"test_[01]\.h5", str(output_fname), "--use-regex"])
-
-    with h5py.File(output_fname) as f:
-        key = next(iter(f.keys()))
-        assert key == "data"
-        assert f[key].shape == (10,)

--- a/ftag/tests/test_vds.py
+++ b/ftag/tests/test_vds.py
@@ -373,3 +373,21 @@ def test_main():
             assert key == "data"
             assert f[key].shape == (30,)
             assert f[key].attrs["key"] == "value"
+
+
+def test_main_regex_hyphenated_alias_defaults_to_cwd(monkeypatch, tmp_path):
+    """Test documented regex option spelling and default regex directory."""
+    for i in range(3):
+        fname = tmp_path / f"test_{i}.h5"
+        with h5py.File(fname, "w") as f:
+            f.create_dataset("data", data=[i] * 5)
+
+    monkeypatch.chdir(tmp_path)
+    output_fname = tmp_path / "out.h5"
+
+    main([r"test_[01]\.h5", str(output_fname), "--use-regex"])
+
+    with h5py.File(output_fname) as f:
+        key = next(iter(f.keys()))
+        assert key == "data"
+        assert f[key].shape == (10,)

--- a/ftag/tests/test_working_points.py
+++ b/ftag/tests/test_working_points.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile, mkdtemp
 from types import SimpleNamespace
@@ -599,3 +600,14 @@ def test_main_with_output_file(ttbar_file, zprime_file):
 
     assert out is None
     assert outfile_path.exists()
+
+
+def test_main_without_explicit_args_uses_sys_argv(monkeypatch, capsys):
+    """Test console-entry-point style invocation."""
+    monkeypatch.setattr(sys, "argv", ["wps", "--help"])
+
+    with pytest.raises(SystemExit) as err:
+        main()
+
+    assert err.value.code == 0
+    assert "Calculate tagger working points." in capsys.readouterr().out

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -35,7 +35,6 @@ def parse_args(args: Any | None) -> argparse.Namespace:
     parser.add_argument("output", type=Path, help="path to output virtual file")
     parser.add_argument(
         "--use_regex",
-        "--use-regex",
         action="store_true",
         help="treat PATTERN as a regular expression instead of a glob",
     )

--- a/ftag/vds.py
+++ b/ftag/vds.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import glob
 import re
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -36,13 +35,13 @@ def parse_args(args: Any | None) -> argparse.Namespace:
     parser.add_argument("output", type=Path, help="path to output virtual file")
     parser.add_argument(
         "--use_regex",
+        "--use-regex",
         action="store_true",
         help="treat PATTERN as a regular expression instead of a glob",
     )
     parser.add_argument(
         "--regex_path",
         type=str,
-        required="--use_regex" in (args or sys.argv),
         default=None,
         help="directory whose entries the regex is applied to "
         "(defaults to the current working directory)",
@@ -314,6 +313,7 @@ def create_virtual_file(
 
     # Use regex to find input files else use glob
     if use_regex is True:
+        regex_path = regex_path or str(Path.cwd())
         matched = glob_re(pattern_str, regex_path)
         fnames = regex_files_from_dir(matched, regex_path)
     else:

--- a/ftag/working_points.py
+++ b/ftag/working_points.py
@@ -22,13 +22,14 @@ if TYPE_CHECKING:  # pragma: no cover
     from ftag.labels import Label, LabelContainer
 
 
-def parse_args(args: Sequence[str]) -> argparse.Namespace:
+def parse_args(args: Sequence[str] | None) -> argparse.Namespace:
     """Parse the input arguments into a Namespace.
 
     Parameters
     ----------
-    args : Sequence[str]
-        Sequence of string inputs to the script
+    args : Sequence[str] | None
+        Sequence of string inputs to the script. If not provided, arguments are
+        read from the command line.
 
     Returns
     -------
@@ -513,13 +514,13 @@ def get_efficiencies(args: argparse.Namespace) -> dict | None:
         return out
 
 
-def main(args: Sequence[str]) -> dict | None:
+def main(args: Sequence[str] | None = None) -> dict | None:
     """Main function to run working point calculation.
 
     Parameters
     ----------
-    args : Sequence[str]
-        Input arguments
+    args : Sequence[str] | None, optional
+        Input arguments. If not provided, arguments are read from the command line.
 
     Returns
     -------


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Fix `wps` console entry point invocation by allowing `main()` and `parse_args()` to parse command-line arguments when called without explicit args.
* Add `--use-regex` as an alias for `vds --use_regex`, preserving the existing underscore spelling for compatibility.
* Make `vds` regex mode default `--regex_path` to the current working directory, matching the existing help text.
* Add regression tests for the `wps` entry point path and documented `vds --use-regex` behavior.

Relates to the following issues

* Closes #155
* Closes #156
* Closes #157

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
