### PR TITLE
Fix docs examples and local build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ env/
 
 # UV files
 uv.lock
+
+# Generated docs files
+docs/source/examples/example.md
+docs/source/examples/example_files/

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This is a collection of Python tools for working with files produced with the FTAG [ntuple dumper](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-dataset-dumper/).
 The code is intended to be used a [library](https://iscinumpy.dev/post/app-vs-library/) for other projects.
-Please see the [example notebook](ftag/example.ipynb) for usage.
+Please see the [examples](https://umami-hep.github.io/atlas-ftag-tools/main/examples/index.html) for usage.
 
 # Quickstart 
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
 - Refactored `find_metadata.py` into a formal `MetadataFinder` class to improve modularity and facilitate integration with the ftag library for UPP. [#153](https://github.com/umami-hep/atlas-ftag-tools/pull/153)
+- Fix documentation examples and local docs build [#162](https://github.com/umami-hep/atlas-ftag-tools/pull/162)
 
 ### [v0.3.2](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.2) (25.02.2026)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,9 @@
 
 ### [Latest]
 
+- Fix documentation examples and local docs build [#162](https://github.com/umami-hep/atlas-ftag-tools/pull/162)
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
 - Refactored `find_metadata.py` into a formal `MetadataFinder` class to improve modularity and facilitate integration with the ftag library for UPP. [#153](https://github.com/umami-hep/atlas-ftag-tools/pull/153)
-- Fix documentation examples and local docs build [#162](https://github.com/umami-hep/atlas-ftag-tools/pull/162)
 
 ### [v0.3.2](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.2) (25.02.2026)
 

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -9,6 +9,12 @@ python -m pip install -r docs/requirements.txt
 # add current working directory to PYTHONPATH such that package is found
 export PYTHONPATH=$PWD:$PYTHONPATH
 
+# convert notebook examples included by docs/source/examples/index.md
+jupyter nbconvert ftag/example.ipynb \
+    --to markdown \
+    --output example \
+    --output-dir docs/source/examples
+
 # build the documentation
 rm -rf docs/_*
 python docs/sphinx_build_multiversion.py

--- a/docs/source/examples/index.md
+++ b/docs/source/examples/index.md
@@ -13,11 +13,14 @@ The script is `working_points.py` and can be run after installing this package w
 wps \
     --ttbar "path/to/ttbar/*.h5" \
     --tagger GN2v01 \
-    --fc 0.1
+    --fc 0.1 \
+    --fu 0.8 \
+    --ftau 0.1 \
+    --effs 60 70 77 85
 ```
 
-Both the `--tagger` and `--fc` options accept a list if you want to get the WPs for multiple taggers.
-If you are doing c-tagging or xbb-tagging, dedicated fx arguments are available ()you can find them all with `-h`.
+Both the `--tagger` and fraction options accept a list if you want to get the WPs for multiple taggers.
+If you are doing c-tagging or xbb-tagging, dedicated fraction arguments are available; you can find them all with `-h`.
 
 If you want to use the `ttbar` WPs get the efficiencies and rejections for the `zprime` sample, you can add `--zprime "path/to/zprime/*.h5"` to the command.
 Note that a default selection of $p_T > 250 ~GeV$ to jets in the `zprime` sample.
@@ -28,19 +31,21 @@ By default the working points are printed to the terminal, but you can save the 
 
 See `wps --help` for more options and information.
 
-## Calculate efficiency at discriminant cut 
+## Calculate efficiency at discriminant cut
 
 The same script can be used to calculate the efficiency and rejection values at a given discriminant cut value.
-The script `working_points.py` can be run after intalling this package as follows
+The script `working_points.py` can be run after installing this package as follows
 
 ```
 wps \
     --ttbar "path/to/ttbar/*.h5" \
     --tagger GN2v01 \
-    --fx 0.1
+    --fc 0.1 \
+    --fu 0.8 \
+    --ftau 0.1 \
     --disc_cuts 1.0 1.5
 ```
-The `--tagger`, `--fx`, and `--outfile` follow the same procedure as in the 'Calculate WPs' script as described above.
+The `--tagger`, fraction arguments, and `--outfile` follow the same procedure as in the 'Calculate WPs' script as described above.
 
 ## H5 Utils
 
@@ -70,23 +75,23 @@ You can also regex match files located in a different folder, specifying the opt
 See `vds --help` for more options and information.
 
 
-### [h5move](ftag/hdf5/h5move.py)
+### h5move
 
 A script to move/rename datasets inside an h5file.
 Useful for correcting discrepancies between group names.
-See [h5move.py](ftag/hdf5/h5move.py) for more info.
+See the `h5move` command help or the {mod}`ftag.hdf5.h5move` API documentation for more info.
 
 
-### [h5split](ftag/hdf5/h5split.py)
+### h5split
 
 A script to split a large h5 file into several smaller files.
 Useful if output files are too large for EOS/grid storage.
-See [h5split.py](ftag/hdf5/h5split.py) for more info.
+See the `h5split` command help or the {mod}`ftag.hdf5.h5split` API documentation for more info.
 
 ## Extensive Examples
 
 The content below is generated automatically from `ftag/example.ipynb`.
 
 ```{include} example.md
-:level: 3
+:heading-offset: 2
 ```


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `wps` examples to include required efficiency and fraction arguments.
* Generate the notebook-derived `example.md` in the local docs build script and ignore generated docs artifacts.
* Fix minor docs typos, replace unresolved source-file links with API references, and update the included notebook heading option.
* Replace the README notebook link with the rendered examples page to avoid unresolved links in Sphinx.

Relates to the following issues

* Closes #159
* Closes #160
* Closes #161

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
