### PR TITLE
Update contributor workflow docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update contributor workflow documentation [#165](https://github.com/umami-hep/atlas-ftag-tools/pull/165)
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
 - Refactored `find_metadata.py` into a formal `MetadataFinder` class to improve modularity and facilitate integration with the ftag library for UPP. [#153](https://github.com/umami-hep/atlas-ftag-tools/pull/153)
 

--- a/docs/source/dev_guidelines/index.md
+++ b/docs/source/dev_guidelines/index.md
@@ -37,16 +37,16 @@ pre-commit run --all-files
 
 | Tool | Checked in CI | Fix command |
 |------|---------------|-------------|
-| **black** | formatting | `black .` |
 | **ruff** (`pyproject.toml`) | lint + simple refactors | `ruff check . --fix` |
-| **mypy** | type safety | `mypy ftag` |
+| **ruff format** | formatting | `ruff format .` |
+| **mypy** | type safety | `pre-commit run mypy --all-files` |
 | **isort** (via ruff) | import order | auto-fixed by *ruff* |
 | **pre-commit** | umbrella runner | `pre-commit run --all-files` |
 
 ### How the hook chain works
 
 ```
-pre-commit ➜ ruff ➜ black ➜ mypy
+pre-commit ➜ ruff ➜ ruff format ➜ mypy ➜ yamllint ➜ pydoclint
 ```
 
 If a stage fails the commit is rejected. Run the hook manually to fix issues
@@ -59,7 +59,7 @@ pre-commit run --all-files
 ## 4  Testing strategy
 
 * **Unit tests** live in `ftag/tests/` and follow the *pytest* conventions.
-* CI executes the suite on 3 Python versions (3.9, 3.11, 3.12) and uploads a coverage report.
+* CI executes the suite on Python 3.10, 3.11, 3.12, 3.13, and 3.14 and uploads a coverage report.
 
 ```bash
 # local one-liner


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Replace stale Black references in the developer guidelines with the current Ruff formatting workflow.
* Update the documented hook chain to match the configured pre-commit hooks.
* Point mypy guidance at the pre-commit hook rather than the misleading direct `mypy ftag` command.
* Update the documented CI Python test matrix to Python 3.10 through 3.14.

Relates to the following issues

* Closes #163
* Closes #164

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
