### PR TITLE
Clean lint and AutoAPI doc warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Clean lint and AutoAPI documentation warnings [#168](https://github.com/umami-hep/atlas-ftag-tools/pull/168)
 - Adding LZ4 to H5Writer as Default [#152](https://github.com/umami-hep/atlas-ftag-tools/pull/152)
 - Refactored `find_metadata.py` into a formal `MetadataFinder` class to improve modularity and facilitate integration with the ftag library for UPP. [#153](https://github.com/umami-hep/atlas-ftag-tools/pull/153)
 

--- a/ftag/hdf5/h5add_col.py
+++ b/ftag/hdf5/h5add_col.py
@@ -17,61 +17,19 @@ from ftag.hdf5.h5writer import H5Writer
 def merge_dicts(dicts: list[dict[str, dict[str, np.ndarray]]]) -> dict[str, dict[str, np.ndarray]]:
     """Merges a list of dictionaries.
 
-    Each dict is of the form:
-     {
-        group1: {
-            variable_1: np.array
-            variable_2: np.array
-        },
-        group2: {
-            variable_1: np.array
-            variable_2: np.array
-        }
-     }
-
-     E.g.
-
-     dict1 = {
-        "jets": {
-            "pt": np.array([1, 2, 3]),
-            "eta": np.array([4, 5, 6])
-        },
-    }
-    dict2 = {
-        "jets": {
-            "phi": np.array([7, 8, 9]),
-            "energy": np.array([10, 11, 12])
-        },
-    }
-
-    merged = {
-        "jets": {
-            "pt": np.array([1, 2, 3]),
-            "eta": np.array([4, 5, 6]),
-            "phi": np.array([7, 8, 9]),
-            "energy": np.array([10, 11, 12])
-        }
-    }
+    Each input dictionary is keyed by group name. The nested dictionaries map
+    variable names to arrays. Variables from later dictionaries are appended to
+    the corresponding group unless a variable with the same name already exists.
 
     Parameters
     ----------
     dicts : list[dict[str, dict[str, np.ndarray]]]
-        List of dictionaries to merge. Each dictionary should be of the form:
+        Dictionaries to merge.
 
     Returns
     -------
     dict[str, dict[str, np.ndarray]]
-        Merged dictionary of the form:
-        {
-            group1: {
-                variable_1: np.array
-                variable_2: np.array
-            },
-            group2: {
-                variable_1: np.array
-                variable_2: np.array
-            }
-        }
+        Merged dictionary with the same nested structure as the input.
 
     Raises
     ------
@@ -155,19 +113,9 @@ def h5_add_column(
     output_file : str | Path
         Output h5 file to write to.
     append_function : Callable | list[Callable]
-        A function, or list of functions, which take a batch from H5Reader and returns a dictionary
-        of the form:
-            {
-                group1 : {
-                    new_column1 : data,
-                    new_column2 : data,
-                },
-                group2 : {
-                    new_column3 : data,
-                    new_column4 : data,
-                },
-                ...
-            }
+        A function, or list of functions, which take a batch from H5Reader and return a
+        dictionary keyed by group name. The nested dictionaries map new column names to
+        arrays.
     num_jets : int, optional
         Number of jets to read from the input file. If -1, reads all jets. By default -1.
     input_groups : list[str] | None, optional

--- a/ftag/tests/test_find_metadata.py
+++ b/ftag/tests/test_find_metadata.py
@@ -86,8 +86,8 @@ class TestMetadataFinder:
         finder = MetadataFinder(mock_h5)
         with patch.object(finder, "_download_db", return_value=str(db_file)):
             meta = finder._query_xsecdb("mc23", 601229, "e8514")
-            assert meta["cross_section_pb"] == 0.015
-            assert meta["genFiltEff"] == 1.0
+            assert meta["cross_section_pb"] == pytest.approx(0.015)
+            assert meta["genFiltEff"] == pytest.approx(1.0)
 
     def test_query_xsecdb_not_found(self, mock_h5, tmp_path):
         """Cover branch where _query_xsecdb returns None when no data is found."""
@@ -122,7 +122,7 @@ class TestMetadataFinder:
         # Verify results
         with h5py.File(mock_h5, "r") as f:
             assert "metadata/601229/cross_section_pb" in f
-            assert f["metadata/601229/cross_section_pb"][()] == 0.015
+            assert f["metadata/601229/cross_section_pb"][()] == pytest.approx(0.015)
 
     def test_inject_metadata_overwrite(self, mock_h5):
         """Ensure the overwrite logic 'if k in g: del g[k]' is executed."""
@@ -144,7 +144,7 @@ class TestMetadataFinder:
             finder.inject_metadata()
 
         with h5py.File(mock_h5, "r") as f:
-            assert f[f"metadata/{dsid}/cross_section_pb"][()] == 0.015
+            assert f[f"metadata/{dsid}/cross_section_pb"][()] == pytest.approx(0.015)
 
     # --- Exception Branch Tests ---
     def test_inject_metadata_fail_branches(self, mock_h5, capsys):


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Replace direct floating-point equality checks in `test_find_metadata.py` with `pytest.approx`.
* Simplify nested dictionary examples in `h5add_col.py` docstrings so AutoAPI renders them without docutils errors.

Relates to the following issues

* Closes #166
* Closes #167

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
