### PR TITLE
Handle empty inputs in H5Reader

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-
+- Handle empty inputs in `H5Reader`: constructing/streaming/loading a reader whose files contain no global objects (or a wildcard resolving to only-empty files) now yields an empty result instead of raising `ZeroDivisionError`/`ValueError`
 
 ### [v0.3.5](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.5) (30.06.2026)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Handle empty inputs in `H5Reader`: constructing/streaming/loading a reader whose files contain no global objects (or a wildcard resolving to only-empty files) now yields an empty result instead of raising `ZeroDivisionError`/`ValueError`
+- Handle empty inputs in `H5Reader`: reading a sample with no global objects now yields an empty result instead of raising [#173](https://github.com/umami-hep/atlas-ftag-tools/pull/173)
 
 ### [v0.3.5](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.5) (30.06.2026)
 

--- a/ftag/hdf5/h5reader.py
+++ b/ftag/hdf5/h5reader.py
@@ -145,6 +145,10 @@ class H5SingleReader:
         start: int = 0,
         skip_batches: int = 0,
     ) -> Generator:
+        # Nothing to read from an empty file (or one whose weighted batch size rounds to zero)
+        if self.num_global_objects == 0 or self.batch_size == 0:
+            return
+
         if num_global_objects is None:
             num_global_objects = self.num_global_objects
         if skip_batches > 0:
@@ -302,7 +306,11 @@ class H5Reader:
                 for f in self.fname
             ]
             num_total = sum(rows_per_file)
-            self.weights = [num / num_total for num in rows_per_file]
+            self.weights = (
+                [num / num_total for num in rows_per_file]
+                if num_total > 0
+                else [0.0 for _ in rows_per_file]
+            )
 
         self.batch_sizes = [int(w * self.batch_size) for w in self.weights]
 
@@ -388,6 +396,10 @@ class H5Reader:
         Generator
             Generator of batches of selected global objects.
         """
+        # Nothing to stream if no global objects are present in any input file
+        if self.num_global_objects == 0:
+            return
+
         # Check if number of global objects is given, if not, set to maximum available
         if num_global_objects is None:
             num_global_objects = self.num_global_objects
@@ -543,8 +555,17 @@ class H5Reader:
                 if name in data:
                     data[name].append(array)
 
-        # concatenate batches
-        return {name: np.concatenate(array) for name, array in data.items()}
+        # concatenate batches (fall back to typed empty arrays if nothing was read)
+        dtypes = None
+        result = {}
+        for name, array in data.items():
+            if array:
+                result[name] = np.concatenate(array)
+            else:
+                if dtypes is None:
+                    dtypes = self.dtypes(variables)
+                result[name] = np.empty(0, dtype=dtypes[name])
+        return result
 
     def estimate_available_global_objects(self, cuts: Cuts, num: int = 1_000_000) -> int:
         """Estimate the number of global objects available after selection cuts.

--- a/ftag/tests/hdf5/test_h5reader.py
+++ b/ftag/tests/hdf5/test_h5reader.py
@@ -409,6 +409,56 @@ def test_batch_reader(h5_files):
             assert sel["index"].max() < upper
 
 
+def _write_jets_file(path, num_jets, source=0):
+    jets = np.zeros(num_jets, dtype=[("pt", "f4"), ("source", "i4")])
+    jets["pt"] = 1.0
+    jets["source"] = source
+    with h5py.File(path, "w") as f:
+        f.create_dataset("jets", data=jets)
+
+
+def test_empty_reader_file_list(tmp_path):
+    # all inputs empty: construct, stream and load without crashing
+    paths = [tmp_path / f"empty_{i}.h5" for i in range(3)]
+    for p in paths:
+        _write_jets_file(p, 0)
+
+    reader = H5Reader(paths, batch_size=100, shuffle=False)
+    assert reader.num_global_objects == 0
+    assert list(reader.stream({"jets": ["pt"]})) == []
+
+    loaded = reader.load({"jets": ["pt"]}, num_global_objects=-1)
+    assert loaded["jets"].shape == (0,)
+    assert loaded["jets"].dtype.names == ("pt",)
+
+
+def test_empty_reader_wildcard(tmp_path):
+    # ftag-data-mc use case: a wildcard resolving to only-empty files
+    for i in range(3):
+        _write_jets_file(tmp_path / f"empty_{i}.h5", 0)
+
+    reader = H5Reader(str(tmp_path / "*.h5"), batch_size=100, shuffle=False)
+    assert reader.num_global_objects == 0
+    assert list(reader.stream({"jets": ["pt"]})) == []
+
+
+def test_reader_mixed_empty_and_nonempty(tmp_path):
+    # a raw glob list with empty files must not crash and must return all real jets
+    _write_jets_file(tmp_path / "a_empty.h5", 0)
+    _write_jets_file(tmp_path / "b_full.h5", 500, source=1)
+    _write_jets_file(tmp_path / "c_full.h5", 300, source=2)
+
+    paths = sorted(tmp_path.glob("*.h5"))
+    reader = H5Reader(paths, batch_size=100, shuffle=False)
+    assert reader.num_global_objects == 800
+
+    total = 0
+    for batch in reader.stream({"jets": ["pt", "source"]}):
+        total += len(batch["jets"])
+        assert set(np.unique(batch["jets"]["source"])).issubset({1, 2})
+    assert total == 800
+
+
 def test_single_batch_reader(h5_files):
     reader = H5SingleReader(h5_files[0], batch_size=1000, shuffle=False)
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Make `H5Reader` robust to inputs that contain no global objects. Previously, a sample whose files all have zero rows crashed at construction with `ZeroDivisionError` (per-file weights `0/0`), and related paths failed downstream. All four spots now degrade gracefully to an empty result:
  * `H5Reader.__post_init__` — set weights to `0.0` when `num_total == 0` instead of dividing by zero
  * `H5Reader.stream` — return an empty generator when no global objects are present (avoids `num / self.num_global_objects` div-by-zero)
  * `H5SingleReader.stream` — skip files whose (rounded) batch size is zero, avoiding `range(..., 0)` `ValueError` (covers empty files and tiny files in a mixed list)
  * `H5Reader.load` — return typed empty arrays instead of `np.concatenate([])`
* Add regression tests for the all-empty file list, all-empty wildcard pattern, and a mixed empty/non-empty list.

This lets callers hand `H5Reader` a wildcard (or raw glob list) that resolves to only-empty part-files without pre-filtering them out.

Relates to the following issues

*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
