### PR TITLE
Rename flavour_label to class_label in the HDF5 writer and mock data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Rename `flavour_label` to `class_label` in the HDF5 writer and mock data (breaking API change) [#174](https://github.com/umami-hep/atlas-ftag-tools/pull/174)
 - Handle empty inputs in `H5Reader`: reading a sample with no global objects now yields an empty result instead of raising [#173](https://github.com/umami-hep/atlas-ftag-tools/pull/173)
 
 ### [v0.3.5](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.5) (30.06.2026)

--- a/ftag/hdf5/h5writer.py
+++ b/ftag/hdf5/h5writer.py
@@ -34,8 +34,8 @@ class H5Writer:
     global_objects_name : str, optional
         Name of the global object dataset. This dataset is used to determine batch
         sizes during writing. Default is ``"jets"``.
-    add_flavour_label : bool, optional
-        If ``True``, append a ``"flavour_label"`` field of type ``i4`` to the
+    add_class_label : bool, optional
+        If ``True``, append a ``"class_label"`` field of type ``i4`` to the
         global object dataset if it is not already present. Default is ``False``.
     compression : str | None, optional
         Compression algorithm to use. Supported values are ``None``,
@@ -82,7 +82,7 @@ class H5Writer:
     dtypes: dict[str, np.dtype]
     shapes: dict[str, tuple[int, ...]]
     global_objects_name: str = "jets"
-    add_flavour_label: bool = False
+    add_class_label: bool = False
     compression: str | None = "lz4"
     compression_opts: int | None = None
     precision: str | None = "full"
@@ -316,10 +316,10 @@ class H5Writer:
         """
         if (
             name == self.global_objects_name
-            and self.add_flavour_label
-            and "flavour_label" not in dtype.names
+            and self.add_class_label
+            and "class_label" not in dtype.names
         ):
-            dtype = np.dtype([*dtype.descr, ("flavour_label", "i4")])
+            dtype = np.dtype([*dtype.descr, ("class_label", "i4")])
 
         fp_vars = self.full_precision_vars or []
         dtype = np.dtype([

--- a/ftag/mock.py
+++ b/ftag/mock.py
@@ -25,7 +25,7 @@ JET_VARS = [
     ("GhostBHadronsFinalCount", "i4"),
     ("GhostCHadronsFinalCount", "i4"),
     ("n_truth_promptLepton", "i4"),
-    ("flavour_label", "i4"),
+    ("class_label", "i4"),
 ]
 
 TRACK_VARS = [
@@ -133,7 +133,7 @@ def mock_jets(num_jets=1000) -> np.ndarray:
     rng = np.random.default_rng(42)
     jets_dtype = np.dtype(JET_VARS)
     jets = u2s(rng.random((num_jets, len(JET_VARS))), jets_dtype)
-    jets["flavour_label"] = rng.choice([0, 4, 5], size=num_jets)
+    jets["class_label"] = rng.choice([0, 4, 5], size=num_jets)
     jets["pt"] *= 400e3
     jets["mass"] *= 50e3
     jets["eta"] = (jets["eta"] - 0.5) * 6.0

--- a/ftag/tests/hdf5/test_h5writer.py
+++ b/ftag/tests/hdf5/test_h5writer.py
@@ -530,29 +530,29 @@ def test_from_file_override_compression(tmp_path):
         assert f["tracks"].compression_opts == 7
 
 
-def test_add_flavour_label(tmp_path, jet_dtype):
+def test_add_class_label(tmp_path, jet_dtype):
     writer = H5Writer(
-        dst=Path(tmp_path) / "test_flavour_label.h5",
+        dst=Path(tmp_path) / "test_class_label.h5",
         dtypes={"jets": jet_dtype},
         shapes={"jets": (10,)},
-        add_flavour_label=True,
+        add_class_label=True,
     )
 
-    assert "flavour_label" in _named_fields(writer.file["jets"].dtype)
+    assert "class_label" in _named_fields(writer.file["jets"].dtype)
     writer.close()
 
 
-def test_add_flavour_label_does_not_duplicate(tmp_path):
-    jet_dtype_with_label = np.dtype([("pt", "f4"), ("eta", "f4"), ("flavour_label", "i4")])
+def test_add_class_label_does_not_duplicate(tmp_path):
+    jet_dtype_with_label = np.dtype([("pt", "f4"), ("eta", "f4"), ("class_label", "i4")])
 
     writer = H5Writer(
-        dst=Path(tmp_path) / "test_flavour_label_existing.h5",
+        dst=Path(tmp_path) / "test_class_label_existing.h5",
         dtypes={"jets": jet_dtype_with_label},
         shapes={"jets": (10,)},
-        add_flavour_label=True,
+        add_class_label=True,
     )
 
-    assert _named_fields(writer.file["jets"].dtype).count("flavour_label") == 1
+    assert _named_fields(writer.file["jets"].dtype).count("class_label") == 1
     writer.close()
 
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Rename the `H5Writer` option `add_flavour_label` to `add_class_label`; the appended field is now `class_label` instead of `flavour_label`
* Rename the `flavour_label` field in the mock jet data to `class_label`

Relates to the following issues

* None

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)