### PR TITLE
Suppress git stderr when probing for a repository

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Suppress git stderr in `is_git_repo` to avoid spurious `fatal: not a git repository` messages when probing non-repositories [#XXX](https://github.com/umami-hep/atlas-ftag-tools/pull/XXX)
+- Suppress git stderr in `is_git_repo` to avoid spurious `fatal: not a git repository` messages when probing non-repositories [#175](https://github.com/umami-hep/atlas-ftag-tools/pull/175)
 - Handle empty inputs in `H5Reader`: reading a sample with no global objects now yields an empty result instead of raising [#173](https://github.com/umami-hep/atlas-ftag-tools/pull/173)
 
 ### [v0.3.5](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.5) (30.06.2026)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Suppress git stderr in `is_git_repo` to avoid spurious `fatal: not a git repository` messages when probing non-repositories [#XXX](https://github.com/umami-hep/atlas-ftag-tools/pull/XXX)
 - Handle empty inputs in `H5Reader`: reading a sample with no global objects now yields an empty result instead of raising [#173](https://github.com/umami-hep/atlas-ftag-tools/pull/173)
 
 ### [v0.3.5](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.3.5) (30.06.2026)

--- a/ftag/git_check.py
+++ b/ftag/git_check.py
@@ -44,13 +44,15 @@ def is_git_repo(path: str | PathLike[str]) -> bool:
 
         git rev-parse --is-inside-work-tree HEAD
 
-    Any non-zero exit status is treated as "not a Git repository". If Git is not
+    Any non-zero exit status is treated as "not a Git repository". Git's standard
+    error is suppressed, so probing a non-repository stays silent. If Git is not
     available on the system, an :class:`OSError` may be raised by :mod:`subprocess`.
     """
     try:
         subprocess.check_output(
             ["git", "rev-parse", "--is-inside-work-tree", "HEAD"],
             cwd=path,
+            stderr=subprocess.DEVNULL,
         )
     except CalledProcessError:
         return False

--- a/ftag/tests/test_git_check.py
+++ b/ftag/tests/test_git_check.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import sys
 import types
 import unittest
-from subprocess import CalledProcessError
+from subprocess import DEVNULL, CalledProcessError
 from unittest.mock import MagicMock, call, patch
 
 from ftag.git_check import (
@@ -25,6 +25,7 @@ class TestIsGitRepo(unittest.TestCase):
         m_check_output.assert_called_once_with(
             ["git", "rev-parse", "--is-inside-work-tree", "HEAD"],
             cwd="/some/path",
+            stderr=DEVNULL,
         )
 
     @patch("ftag.git_check.subprocess.check_output")


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Pass `stderr=subprocess.DEVNULL` to the `git rev-parse` call in `is_git_repo`, so probing a non-repository no longer prints `fatal: not a git repository` to the terminal
* Update the `is_git_repo` docstring and the corresponding unit test assertion

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/atlas-ftag-tools/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/atlas-ftag-tools/)
